### PR TITLE
show table tags(table,tr,td) in conversation email body

### DIFF
--- a/config/purifier.php
+++ b/config/purifier.php
@@ -24,7 +24,7 @@ return [
     'settings'      => [
         'default' => [
             'HTML.Doctype'             => 'HTML 4.01 Transitional',
-            'HTML.Allowed'             => 'div,b,strong,i,em,u,a[href|title],ul,ol,li,p[style],br,span[style],img[width|height|alt|src]',
+            'HTML.Allowed'             => 'div,b,strong,i,em,u,a[href|title],ul,ol,li,p[style],br,span[style],img[width|height|alt|src],table,tr,td',
             //'CSS.AllowedProperties'    => 'font,font-size,font-weight,font-style,font-family,text-decoration,padding-left,color,background-color,text-align',
             'CSS.AllowedProperties'    => 'font-weight,font-style,text-decoration,color,background-color,text-align',
             'AutoFormat.AutoParagraph' => true,


### PR DESCRIPTION
without table tags many emails showed wrongly formatted.