### PR TITLE
Fix To address in customer notification emails

### DIFF
--- a/app/Jobs/SendReplyToCustomer.php
+++ b/app/Jobs/SendReplyToCustomer.php
@@ -112,7 +112,7 @@ class SendReplyToCustomer implements ShouldQueue
         // }
 
         try {
-            Mail::to([['name' => $this->customer->getFullName(), 'email' => $this->customer_email]])
+            Mail::to([['name' => ($this->customer->getFullName() ?: $this->customer_email), 'email' => $this->customer_email]])
                 ->cc($cc_array)
                 ->bcc($bcc_array)
                 ->send(new ReplyToCustomer($this->conversation, $this->threads, $headers, $mailbox));


### PR DESCRIPTION
When creating a new conversation from the control panel, the "To" address is set as empty if there isn't any fullname stored for that address. This will fix the empty string sent in To header by replacing it with the customer email address