### PR TITLE
Enhancement/error free installation

### DIFF
--- a/overrides/RachidLaasri/LaravelInstaller/Controllers/EnvironmentController.php
+++ b/overrides/RachidLaasri/LaravelInstaller/Controllers/EnvironmentController.php
@@ -94,6 +94,8 @@ class EnvironmentController extends Controller
      */
     public function saveWizard(Request $request, Redirector $redirect)
     {
+        $envConfig = $this->EnvironmentManager->getEnvContent();
+
         $rules = config('installer.environment.form.rules');
         $messages = [
             'environment_custom.required_if' => trans('installer_messages.environment.wizard.form.name_required'),

--- a/resources/views/vendor/installer/environment-wizard.blade.php
+++ b/resources/views/vendor/installer/environment-wizard.blade.php
@@ -166,7 +166,7 @@
                     <label for="database_password">
                         Password
                     </label>
-                    <input type="text" name="database_password" id="database_password" value="{{ old('database_password', env('DB_PASSWORD')) }}" />
+                    <input type="text" name="database_password" id="database_password" value="{{ old('database_password', env('DB_PASSWORD')) }}" maxlength="50"/>
                     @if ($errors->has('database_password'))
                         <span class="error-block">
                             <i class="fa fa-fw fa-exclamation-triangle" aria-hidden="true"></i>
@@ -222,7 +222,7 @@
                 </div>
             </div>
             <div class="tab" id="tab4content">
-                
+
                 <div class="form-group {{ $errors->has('admin_email') ? ' has-error ' : '' }}">
                     <label for="admin_email">
                         Email


### PR DESCRIPTION
When there is an error in the installation process (DB Password longer that 50 characters, unable to connect to Database), the error `compact(): Undefined variable: envConfig` is thrown, the full stacktrace can be seen in #343.

In this PR the envConfig (the missing variable) is getting retrieved (67cc30305b531490e5fbb663f4a42575d368c306) and the `maxlength`[1] attribute is being placed on the input field (cca24c8cbd90ecc623ced14eb474d9e12585e5b6).

Close #343

[1] [https://www.w3.org/MarkUp/1995-archive/Elements/INPUT.html](https://www.w3.org/MarkUp/1995-archive/Elements/INPUT.html)