### PR TITLE
Photo URL as Variable in signature

### DIFF
--- a/app/Misc/Mail.php
+++ b/app/Misc/Mail.php
@@ -196,6 +196,7 @@ class Mail
             $vars['{%user.email%}'] = $data['user']->getEmail();
             $vars['{%user.jobTitle%}'] = $data['user']->getJobTitle();
             $vars['{%user.lastName%}'] = $data['user']->last_name;
+            $vars['{%user.photoUrl%}'] = $data['user']->getPhotoUrl();
         }
 
         return strtr($text, $vars);

--- a/app/User.php
+++ b/app/User.php
@@ -635,7 +635,7 @@ class User extends Authenticatable
                 return '';
             }
         } else {
-            return '/img/default-avatar.png';
+            return URL::to('/img/default-avatar.png');
         }
     }
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -152,6 +152,7 @@ var EditorInsertVarButton = function (context) {
 		        '<option value="{%user.jobTitle%}">'+Lang.get("messages.job_title")+'</option>'+
 		        '<option value="{%user.phone%}">'+Lang.get("messages.phone")+'</option>'+
 		        '<option value="{%user.email%}">'+Lang.get("messages.email_addr")+'</option>'+
+		        '<option value="{%user.photoUrl%}">'+Lang.get("messages.photo_url")+'</option>'+
 		    '</optgroup>'+
 	    '</select>';
 

--- a/resources/views/js/vars.blade.php
+++ b/resources/views/js/vars.blade.php
@@ -47,6 +47,7 @@ var LangMessages = {
             "email_addr": "{{ __("Email Address") }}",
             "job_title": "{{ __("Job title") }}",
             "phone": "{{ __("Phone number") }}",
+            "photo_url": "{{ __("Profile Picture (URL)") }}",
             "from_name": "{{ __("From name") }}",
             "user": "{{ __("User") }}",
             "confirm_change_customer": "{{ __("Change the customer to :customer_email?") }}",


### PR DESCRIPTION
As discussed [here](https://github.com/freescout-helpdesk/freescout/issues/281#issuecomment-540992628), this PR adds a variabel `user.photoUrl` for use in the signature.

Finally close #281 