### PR TITLE
Spaces in some conversation titles are replaced by underscores #420

### DIFF
--- a/overrides/Webklex/IMAP/Message.php
+++ b/overrides/Webklex/IMAP/Message.php
@@ -297,7 +297,7 @@ class Message
      */
     private function parseHeader()
     {
-        $this->header = $header = imap_fetchheader($this->client->getConnection(), $this->uid, FT_UID);
+        $this->header = $header = imap_utf8(imap_fetchheader($this->client->getConnection(), $this->uid, FT_UID));
         if ($this->header) {
             $header = imap_rfc822_parse_headers($this->header);
         }
@@ -327,7 +327,7 @@ class Message
         }
 
         if (property_exists($header, 'subject')) {
-            $this->subject = mb_decode_mimeheader($header->subject);
+            $this->subject = $header->subject;
         }
 
         if (property_exists($header, 'date')) {


### PR DESCRIPTION
The problem is in webklex/laravel-imap (old version) and its override, applied to the override the changes proposed in this other pr: https://github.com/Webklex/laravel-imap/pull/175/commits/884bde831e10eb4227d10f1e79b922ce62c3ad70