### PR TITLE
Fix tokenization of multiple emails on copy+paste of multiple emails

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2414,7 +2414,7 @@ function initCustomerSelector(input, custom_options)
 				    }
 				}
 			    // Check if select already has such option
-			    var data = this.$element.select2('data');
+			    var data = this.select2('data');
 			    for (i in data) {
 			    	if (data[i].id == params.term) {
 			    		return null;
@@ -2425,7 +2425,7 @@ function initCustomerSelector(input, custom_options)
 					text: params.term,
 					newOption: true
 			    }
-			},
+			}.bind(input),
 			templateResult: function (data) {
 			    var $result = $("<span></span>");
 


### PR DESCRIPTION
This fixes freescout-helpdesk/freescout#487 with copy+pasting a string containing multiple emailaddresses separated by any of the allowed tokens. Before this patch, all emailaddresses became a single tag.

Before:
![current](https://user-images.githubusercontent.com/680327/74608308-3af12500-50e0-11ea-9e1b-240c344253db.gif)

After:
![fix](https://user-images.githubusercontent.com/680327/74608341-7390fe80-50e0-11ea-9b0c-7341e19fabc8.gif)

I'm aware that the last item is not correctly tokenized. This is due to https://github.com/select2/select2/issues/5076. I'm looking at applying the workaround as well, but it did not immediately work.