### PR TITLE
Remove trailing n from relative date minutes for Dutch systems

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -425,7 +425,7 @@ class User extends Authenticatable
             }
         } else {
             $diff_text = $date->diffForHumans();
-            $diff_text = preg_replace('/minutes?/', 'min', $diff_text);
+            $diff_text = preg_replace('/minute[sn]?/', 'min', $diff_text);
 
             return $diff_text;
         }


### PR DESCRIPTION
In relative dates on a Dutch system the word 'minute' is written as 'minuten'. When shortening this word to 'min' the trailing 'n' remains. This fix makes sure the trailing 'n' is also removed.

Current: `49 minn geleden`
With fix: `49 min geleden`