### PR TITLE
Add commandline arguments to freescout:create-user

### DIFF
--- a/app/Console/Commands/CreateUser.php
+++ b/app/Console/Commands/CreateUser.php
@@ -12,7 +12,7 @@ class CreateUser extends Command
      *
      * @var string
      */
-    protected $signature = 'freescout:create-user';
+    protected $signature = 'freescout:create-user {--role=} {--firstName=} {--lastName=} {--email=} {--password=}';
 
     /**
      * The console command description.
@@ -46,39 +46,56 @@ class CreateUser extends Command
             ).'.model'
         );
         $user = new $class();
-        $fillables = ['role', 'first_name', 'last_name', 'email', 'password'];
-        foreach ($fillables as $key => $fillable) {
-            if ($fillable == 'password') {
-                $user->$fillable = \Hash::make($this->secret(($key + 1).'/'.count($fillables)." User $fillable"));
-            } elseif ($fillable == 'role') {
-                $user->$fillable = $this->ask(($key + 1).'/'.count($fillables)." User $fillable (admin/user)", 'admin');
-                if (!$user->$fillable) {
-                    $user->$fillable = 'admin';
-                }
 
-                while (!in_array($user->$fillable, User::$roles)) {
-                    $this->error('Incorrect role');
-                    $user->$fillable = $this->ask('Please enter valid role');
-                }
-                $user->$fillable = array_flip(User::$roles)[$user->$fillable];
-            } else {
-                $user->$fillable = $this->ask(($key + 1).'/'.count($fillables)." User $fillable");
-
-                if ($fillable == 'email') {
-                    while (!filter_var($user->$fillable, FILTER_VALIDATE_EMAIL)) {
-                        $this->error('Incorrect email address');
-                        $user->$fillable = $this->ask('Please enter valid email address');
-                    }
-                }
+        $user->role = $this->option('role');
+        if ($user->role ) {
+            if (!in_array($user->role , User::$roles)) {
+                $this->error('Invalid role');
+                return false;
+            }
+        } else {
+            $user->role = $this->ask('User role (admin/user)', 'admin');
+            while (!in_array($user->role, User::$roles)) {
+                $this->error('Invalid role');
+                $user->role = $this->ask('Please enter valid role');
             }
         }
+        $user->role = array_flip(User::$roles)[$user->role];
+
+        $user->first_name = $this->option('firstName') ? $this->option('firstName') : $this->ask('User first name');
+        $user->last_name = $this->option('lastName') ? $this->option('lastName') : $this->ask('User last name');
+
+        $user->email = $this->option('email');
+        if ($user->email) {
+            if (!filter_var($user->email, FILTER_VALIDATE_EMAIL)) {
+                $this->error('Invalid email address');
+                return false;
+            }
+        } else {
+            $user->email = $this->ask('User email address');
+            while (!filter_var($user->email, FILTER_VALIDATE_EMAIL)) {
+                $this->error('Incorrect email address');
+                $user->email = $this->ask('Please enter valid email address');
+            }
+        }
+
+        $user->password = \Hash::make($this->option('password') ? $this->option('password') : $this->secret('User password'));
+
         if ($this->confirm('Do you want to create the user?', true)) {
             if ($user->isAdmin()) {
                 $user->invite_state = User::INVITE_STATE_ACTIVATED;
             }
-            $user->save();
-            $this->info("User created (id: {$user->id})");
+
+            try {
+                $user->save();
+            } catch (\Exception $e) {
+                $this->line($e->getMessage());
+                $this->error('User already exists.');
+                return false;
+            }
         }
+
+        $this->info('User created with id: '.$user->id);
 
         return true;
     }


### PR DESCRIPTION
This allows for automation of initial admin account creation together with the already supported `--no-interaction` option.
All options are optional and if not provided will be asked for.

This requirement came up while I was packaging freescout for Cloudron due to popular request.