### PR TITLE
Removing INBOX as default IMAP folder

### DIFF
--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -107,14 +107,7 @@ class FetchEmails extends Command
         // Connect to the Server
         $client->connect();
 
-        // Get INBOX folder
         $folders = [];
-        $folder = $client->getFolder('INBOX');
-
-        if (!$folder) {
-            throw new \Exception('Could not get mailbox folder: INBOX', 1);
-        }
-        $folders[] = $folder;
 
         // Fetch emails from custom IMAP folders.
         if ($mailbox->in_protocol == Mailbox::IN_PROTOCOL_IMAP) {

--- a/app/Http/Controllers/MailboxesController.php
+++ b/app/Http/Controllers/MailboxesController.php
@@ -255,7 +255,7 @@ class MailboxesController extends Controller
 
         // Sometimes background job continues to use old connection settings.
         \Helper::queueWorkRestart();
-        
+
         \Session::flash('flash_success_floating', __('Connection settings saved!'));
 
         return redirect()->route('mailboxes.connection', ['id' => $id]);
@@ -325,9 +325,7 @@ class MailboxesController extends Controller
         // Save all custom folders except INBOX.
         $in_imap_folders = [];
         foreach ($request->in_imap_folders as $imap_folder) {
-            if (mb_strtolower($imap_folder) != 'inbox') {
-                $in_imap_folders[] = $imap_folder;
-            }
+            $in_imap_folders[] = $imap_folder;
         }
         $mailbox->setInImapFolders($in_imap_folders);
 
@@ -537,7 +535,7 @@ class MailboxesController extends Controller
                         $response['msg'] = __(':host is not available on :port port. Make sure that :host address is correct and that outgoing port :port on YOUR server is open.', ['host' => '<strong>'.$mailbox->in_server.'</strong>', 'port' => '<strong>'.$mailbox->in_port.'</strong>']);
                     }
                 }
-                
+
                 if (!$response['msg']) {
                     $test_result = false;
 

--- a/resources/views/mailboxes/connection_incoming.blade.php
+++ b/resources/views/mailboxes/connection_incoming.blade.php
@@ -126,7 +126,6 @@
 
                         <div class="col-sm-6 flexy">
                             <select id="in_imap_folders" class="form-control input-sized" name="in_imap_folders[]" multiple>
-                                <option value="INBOX" selected="selected">INBOX</option>
                                 @foreach ($mailbox->getInImapFolders() as $imap_folder)
                                     <option value="{{ $imap_folder }}" selected="selected">{{ $imap_folder }}</option>
                                 @endforeach


### PR DESCRIPTION
- Stop showing INBOX in view file for `IMAP Folders` field.
- Allow saving INBOX in DB.
- Stop fetching of INBOX folder by default.

Check https://github.com/freescout-helpdesk/freescout/issues/483 for more details.