### PR TITLE
Add option to include the last message in notifications

### DIFF
--- a/app/Jobs/SendNotificationToUsers.php
+++ b/app/Jobs/SendNotificationToUsers.php
@@ -62,11 +62,6 @@ class SendNotificationToUsers implements ShouldQueue
             return;
         }
 
-        // Include only the last two messages if configured
-        if (config('app.email_conv_history') == 'last') {
-          $this->threads = $this->threads->slice(0, 2);
-        }
-
         // All notification for the same conversation has same dummy Message-ID
         $prev_message_id = \App\Misc\Mail::MESSAGE_ID_PREFIX_NOTIFICATION_IN_REPLY.'-'.$this->conversation->id.'-'.md5($this->conversation->id).'@'.$mailbox->getEmailDomain();
         $headers['In-Reply-To'] = '<'.$prev_message_id.'>';

--- a/app/Jobs/SendNotificationToUsers.php
+++ b/app/Jobs/SendNotificationToUsers.php
@@ -62,6 +62,11 @@ class SendNotificationToUsers implements ShouldQueue
             return;
         }
 
+        // Include only the last two messages if configured
+        if (config('app.email_conv_history') == 'last') {
+       	  $this->threads = $this->threads->slice (0, 2);
+       	}
+
         // All notification for the same conversation has same dummy Message-ID
         $prev_message_id = \App\Misc\Mail::MESSAGE_ID_PREFIX_NOTIFICATION_IN_REPLY.'-'.$this->conversation->id.'-'.md5($this->conversation->id).'@'.$mailbox->getEmailDomain();
         $headers['In-Reply-To'] = '<'.$prev_message_id.'>';

--- a/app/Jobs/SendNotificationToUsers.php
+++ b/app/Jobs/SendNotificationToUsers.php
@@ -64,7 +64,7 @@ class SendNotificationToUsers implements ShouldQueue
 
         // Include only the last two messages if configured
         if (config('app.email_conv_history') == 'last') {
-          $this->threads = $this->threads->slice (0, 2);
+          $this->threads = $this->threads->slice(0, 2);
         }
 
         // All notification for the same conversation has same dummy Message-ID

--- a/app/Jobs/SendNotificationToUsers.php
+++ b/app/Jobs/SendNotificationToUsers.php
@@ -64,8 +64,8 @@ class SendNotificationToUsers implements ShouldQueue
 
         // Include only the last two messages if configured
         if (config('app.email_conv_history') == 'last') {
-       	  $this->threads = $this->threads->slice (0, 2);
-       	}
+          $this->threads = $this->threads->slice (0, 2);
+        }
 
         // All notification for the same conversation has same dummy Message-ID
         $prev_message_id = \App\Misc\Mail::MESSAGE_ID_PREFIX_NOTIFICATION_IN_REPLY.'-'.$this->conversation->id.'-'.md5($this->conversation->id).'@'.$mailbox->getEmailDomain();

--- a/app/Jobs/SendReplyToCustomer.php
+++ b/app/Jobs/SendReplyToCustomer.php
@@ -117,6 +117,11 @@ class SendReplyToCustomer implements ShouldQueue
             $send_previous_messages = true;
         }
 
+        if (config('app.email_conv_history') == 'last') {
+            $send_previous_messages = true;
+            $this->threads = $this->threads->slice(0, 2);
+        }
+
         $send_previous_messages = \Eventy::filter('jobs.send_reply_to_customer.send_previous_messages', $send_previous_messages, $this->last_thread, $this->threads, $this->conversation, $this->customer);
 
         // Remove previous messages.

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -84,6 +84,7 @@
         <div class="col-sm-6">
             <select id="email_conv_history" class="form-control input-sized" name="settings[email_conv_history]" required autofocus>
                 <option value="none" @if (old('settings[email_conv_history]', $settings['email_conv_history']) == 'none')selected="selected"@endif>{{ __('Do not include previous messages') }}</option>
+                <option value="last" @if (old('settings[email_conv_history]', $settings['email_conv_history']) == 'last')selected="selected"@endif>{{ __('Include the last message') }}</option>
                 <option value="full" @if (old('settings[email_conv_history]', $settings['email_conv_history']) == 'full')selected="selected"@endif>{{ __('Send full conversation history') }}</option>
             </select>
 


### PR DESCRIPTION
This adds a third option `Include the last message` to Settings > Conversation history (#447)

In my tests the notification mails look the same as the current 'Send full conversation history' with only the new reply and the one before that included.

I wasn't sure if the code should be added before or after the `\Eventy::filter()`, but it doesn't seem to matter.

~Edit: the staff notifications are still the full list, I don't know where that can be altered.~