### PR TITLE
Add .editorconfig for consistent whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.json]
+insert_final_newline = false


### PR DESCRIPTION
Works great in many editors and on Github