### PR TITLE
Feature/imap inbox not default

### DIFF
--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -107,14 +107,7 @@ class FetchEmails extends Command
         // Connect to the Server
         $client->connect();
 
-        // Get INBOX folder
         $folders = [];
-        $folder = $client->getFolder('INBOX');
-
-        if (!$folder) {
-            throw new \Exception('Could not get mailbox folder: INBOX', 1);
-        }
-        $folders[] = $folder;
 
         // Fetch emails from custom IMAP folders.
         if ($mailbox->in_protocol == Mailbox::IN_PROTOCOL_IMAP) {

--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -131,14 +131,6 @@ class FetchEmails extends Command
             //     // Do nothing
             // }
         }
-        // if (!count($folders)) {
-        //     $folder = $client->getFolder('INBOX');
-
-        //     if (!$folder) {
-        //         throw new \Exception('Could not get mailbox folder: INBOX', 1);
-        //     }
-        //     $folders = [$folder];
-        // }
 
         foreach ($folders as $folder) {
             $this->line('['.date('Y-m-d H:i:s').'] Folder: '.$folder->name);

--- a/app/Http/Controllers/MailboxesController.php
+++ b/app/Http/Controllers/MailboxesController.php
@@ -255,7 +255,7 @@ class MailboxesController extends Controller
 
         // Sometimes background job continues to use old connection settings.
         \Helper::queueWorkRestart();
-        
+
         \Session::flash('flash_success_floating', __('Connection settings saved!'));
 
         return redirect()->route('mailboxes.connection', ['id' => $id]);
@@ -325,9 +325,7 @@ class MailboxesController extends Controller
         // Save all custom folders except INBOX.
         $in_imap_folders = [];
         foreach ($request->in_imap_folders as $imap_folder) {
-            if (mb_strtolower($imap_folder) != 'inbox') {
-                $in_imap_folders[] = $imap_folder;
-            }
+            $in_imap_folders[] = $imap_folder;
         }
         $mailbox->setInImapFolders($in_imap_folders);
 
@@ -537,7 +535,7 @@ class MailboxesController extends Controller
                         $response['msg'] = __(':host is not available on :port port. Make sure that :host address is correct and that outgoing port :port on YOUR server is open.', ['host' => '<strong>'.$mailbox->in_server.'</strong>', 'port' => '<strong>'.$mailbox->in_port.'</strong>']);
                     }
                 }
-                
+
                 if (!$response['msg']) {
                     $test_result = false;
 

--- a/app/Mailbox.php
+++ b/app/Mailbox.php
@@ -11,7 +11,7 @@ class Mailbox extends Model
     use Rememberable;
     // This is obligatory.
     public $rememberCacheDriver = 'array';
-    
+
     /**
      * From Name: name that will appear in the From field when a customer views your email.
      */
@@ -666,7 +666,7 @@ class Mailbox extends Model
      */
     public function getInImapFolders()
     {
-        return \Helper::jsonToArray($this->in_imap_folders);
+        return \Helper::jsonToArray($this->in_imap_folders || '["INBOX"]');
     }
 
     public function outPasswordSafe()

--- a/app/Misc/Mail.php
+++ b/app/Misc/Mail.php
@@ -597,7 +597,7 @@ class Mail
             return null;
         }
 
-        $imap_folders = array_merge(['INBOX'], $mailbox->getInImapFolders());
+        $imap_folders = $mailbox->getInImapFolders();
 
         foreach ($imap_folders as $folder_name) {
             try {

--- a/database/migrations/2019_07_05_370100_add_in_imap_folders_column_to_mailboxes_table.php
+++ b/database/migrations/2019_07_05_370100_add_in_imap_folders_column_to_mailboxes_table.php
@@ -14,7 +14,6 @@ class AddInImapFoldersColumnToMailboxesTable extends Migration
     public function up()
     {
         Schema::table('mailboxes', function (Blueprint $table) {
-            // Additional IMAP folders, INBOX folder is fetched by default.
             $table->text('in_imap_folders')->nullable();
         });
     }

--- a/resources/views/mailboxes/connection_incoming.blade.php
+++ b/resources/views/mailboxes/connection_incoming.blade.php
@@ -126,7 +126,6 @@
 
                         <div class="col-sm-6 flexy">
                             <select id="in_imap_folders" class="form-control input-sized" name="in_imap_folders[]" multiple>
-                                <option value="INBOX" selected="selected">INBOX</option>
                                 @foreach ($mailbox->getInImapFolders() as $imap_folder)
                                     <option value="{{ $imap_folder }}" selected="selected">{{ $imap_folder }}</option>
                                 @endforeach


### PR DESCRIPTION
- Stop showing INBOX in view file for IMAP Folders field.
- Allow saving INBOX in DB.
- Stop fetching of INBOX folder by default.
- INBOX as fallback IMAP folder.

Check https://github.com/freescout-helpdesk/freescout/issues/483 for more details.