### PR TITLE
Add setting for conversation history in user notifications

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -111,6 +111,9 @@ class SettingsController extends Controller
                         'email_conv_history' => [
                             'env' => 'APP_EMAIL_CONV_HISTORY',
                         ],
+                        'email_user_history' => [
+                            'env' => 'APP_EMAIL_USER_HISTORY',
+                        ],
                         'locale' => [
                             'env' => 'APP_LOCALE',
                         ],
@@ -172,6 +175,7 @@ class SettingsController extends Controller
                     'email_branding'       => Option::get('email_branding'),
                     'open_tracking'        => Option::get('open_tracking'),
                     'email_conv_history'   => config('app.email_conv_history'),
+                    'email_user_history'   => config('app.email_user_history'),
                     'enrich_customer_data' => Option::get('enrich_customer_data'),
                     'time_format'          => Option::get('time_format', User::TIME_FORMAT_24),
                     'locale'               => \Helper::getRealAppLocale(),

--- a/app/Jobs/SendNotificationToUsers.php
+++ b/app/Jobs/SendNotificationToUsers.php
@@ -62,6 +62,15 @@ class SendNotificationToUsers implements ShouldQueue
             return;
         }
 
+        // Limit conversation history
+        if (config('app.email_user_history') == 'last') {
+            $this->threads = $this->threads->slice(0, 2);
+        }
+
+        if (config('app.email_user_history') == 'none') {
+     	    $this->threads = $this->threads->slice(0, 1);
+        }
+
         // All notification for the same conversation has same dummy Message-ID
         $prev_message_id = \App\Misc\Mail::MESSAGE_ID_PREFIX_NOTIFICATION_IN_REPLY.'-'.$this->conversation->id.'-'.md5($this->conversation->id).'@'.$mailbox->getEmailDomain();
         $headers['In-Reply-To'] = '<'.$prev_message_id.'>';

--- a/app/Jobs/SendNotificationToUsers.php
+++ b/app/Jobs/SendNotificationToUsers.php
@@ -68,7 +68,7 @@ class SendNotificationToUsers implements ShouldQueue
         }
 
         if (config('app.email_user_history') == 'none') {
-     	    $this->threads = $this->threads->slice(0, 1);
+            $this->threads = $this->threads->slice(0, 1);
         }
 
         // All notification for the same conversation has same dummy Message-ID

--- a/config/app.php
+++ b/config/app.php
@@ -262,11 +262,25 @@ return [
     |--------------------------------------------------------------------------
     | none - send to the customer only agent's reply in the email.
     | 
+    | last - send to the customer the last message in the email.
+    | 
     | full - send to the customer full conversation history in the email.
     |
     |-------------------------------------------------------------------------
     */
     'email_conv_history'    => env('APP_EMAIL_CONV_HISTORY', 'none'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | none - send to the user only agent's reply in the email.
+    | 
+    | last - send to the user the last message in the email.
+    |
+    | full - send to the user full conversation history in the email.
+    |
+    |-------------------------------------------------------------------------
+    */
+    'email_user_history'    => env('APP_EMAIL_USER_HISTORY', 'none'),
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -127,6 +127,22 @@
         </div>
     </div>
 
+    <h3 class="subheader">{{ __('Emails to Users') }}</h3>
+
+    <div class="form-group{{ $errors->has('settings[email_user_history]') ? ' has-error' : '' }}">
+        <label for="email_user_history" class="col-sm-2 control-label">{{ __('Conversation History') }}</label>
+
+        <div class="col-sm-6">
+            <select id="email_user_history" class="form-control input-sized" name="settings[email_user_history]" required autofocus>
+                <option value="none" @if (old('settings[email_user_history]', $settings['email_user_history']) == 'none')selected="selected"@endif>{{ __('Do not include previous messages') }}</option>
+                <option value="last" @if (old('settings[email_user_history]', $settings['email_user_history']) == 'last')selected="selected"@endif>{{ __('Include the last message') }}</option>
+                <option value="full" @if (old('settings[email_user_history]', $settings['email_user_history']) == 'full')selected="selected"@endif>{{ __('Send full conversation history') }}</option>
+            </select>
+
+            @include('partials/field_error', ['field'=>'settings.email_user_history'])
+        </div>
+    </div>
+
     <div class="form-group">
         <div class="col-sm-6 col-sm-offset-2">
             <button type="submit" class="btn btn-primary">


### PR DESCRIPTION
In follow up to #535, this adds a new section Manage > Settings > General > **Emails to Users** with the same **Conversation History** drop menu and its default setting as in _Emails to Customers_.

This allows to configure the notifications for better GDPR compliance, by setting the history to 'none' for users and 'last' for the customer for their convenience. This way there are less copies of PII amongst staff, reducing the risk of data leaks.

Additionally I added a missing comment I forgot about in my other PR #535.