### PR TITLE
Fix for reply on notification e-mail not assigned to original conversion

### DIFF
--- a/resources/views/emails/user/notification.blade.php
+++ b/resources/views/emails/user/notification.blade.php
@@ -254,7 +254,7 @@
 		<tr>
 			<td height="0" style="font-size: 0px; line-height: 0px; color:#ffffff;">	                    	
 				{{-- Addition to Message-ID header to detect relies --}}
-				<div style="font-size: 0px; line-height: 0px; color:#ffffff !important; display:none;">{{ \MailHelper::getMessageMarker($headers['Message-ID']) }}</div>
+				<div style="font-size: 0px; line-height: 0px; color:#ffffff !important;">{{ \MailHelper::getMessageMarker($headers['Message-ID']) }}</div>
 			</td>
 		</tr>
 	</table>


### PR DESCRIPTION
Mac mail (at least) removes elements that are set to display none when you're replying. Because the {#FS:****#} was in an hidden div it was removed, and freescout was not able anymore to relate the reply to the original conversation. Simply removing the display none fixes that.