### PR TITLE
Check if ORIG_SCRIPT_NAME exists before using it

### DIFF
--- a/app/Misc/Helper.php
+++ b/app/Misc/Helper.php
@@ -994,7 +994,7 @@ class Helper
                 $subdirectory = $_SERVER['SCRIPT_NAME'];
             } elseif (basename($_SERVER['PHP_SELF']) === $filename) {
                 $subdirectory = $_SERVER['PHP_SELF'];
-            } elseif (basename($_SERVER['ORIG_SCRIPT_NAME']) === $filename) {
+            } elseif (array_key_exists('ORIG_SCRIPT_NAME', $_SERVER) && basename($_SERVER['ORIG_SCRIPT_NAME']) === $filename) {
                 $subdirectory = $_SERVER['ORIG_SCRIPT_NAME']; // 1and1 shared hosting compatibility
             } else {
                 // Backtrack up the script_filename to find the portion matching


### PR DESCRIPTION
I ran into an weird issue that it tried to use `$_SERVER['ORIG_SCRIPT_NAME']` while it wasn't defined. Therefore these changes check if this array key even exists before using it.