### PR TITLE
Customer factory now generates json for 'phones' field.

### DIFF
--- a/database/factories/CustomerFactory.php
+++ b/database/factories/CustomerFactory.php
@@ -8,6 +8,6 @@ $factory->define(App\Customer::class, function (Faker $faker) {
         'first_name' => $faker->firstName,
         'last_name'  => $faker->lastName,
         'job_title'  => $faker->jobTitle,
-        'phones'     => Customer::formatPhones([['value' => $faker->phoneNumber, 'type' => Customer::PHONE_TYPE_WORK]]),
+        'phones'     => json_encode(Customer::formatPhones([['value' => $faker->phoneNumber, 'type' => Customer::PHONE_TYPE_WORK]])),
     ];
 });


### PR DESCRIPTION
I have wrapped the code in json_encode as I can see from the migration file comment that this database field is json.

Issue: https://github.com/freescout-helpdesk/freescout/issues/706#issue-684149054

Previous output:
```php
array:1 [
  0 => array:2 [
    "value" => "290-258-2556 x0587"
    "type" => 1
  ]
]
```
New output: 
```php
"[{"value":"(519) 427-5834","type":1}]"
```

Manual test:

![image](https://user-images.githubusercontent.com/34506780/90975999-47dc4e80-e531-11ea-8b40-f94dea165741.png)
