### PR TITLE
Rescale large images for readability (#612)

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -2224,6 +2224,9 @@ button.conv-checkbox-clear {
     text-align: center;
     top: 75px;
 }*/
+.thread-content	p img {
+    max-width: 100%;
+}
 .conv-new #conv-toolbar {
     border-bottom: 1px solid #d4d9dd;
     padding: 6px 0 7px 0;


### PR DESCRIPTION
This CSS fix for issue #612 makes sure that large images are limited to a maximum width of 100% of its parent `<p>` tag.

Because all attached images are already available for download at the bottom of the message, the image does not need to be linked.

I have tested this on the latest stable versions of Safari, Firefox and Edge on macOS and Safari & Firefox on iOS.