### PR TITLE
Issue 490: Mailbox Managers and per user management permissions

### DIFF
--- a/app/Mailbox.php
+++ b/app/Mailbox.php
@@ -98,6 +98,16 @@ class Mailbox extends Model
 {%mailbox.name%}</span>';
 
     /**
+     * Mailbox User Access Permissions.
+     */
+    public static $USER_ACCESS_PERMISSIONS = [
+        'Edit Mailbox' => 'edit',
+        'Permissions' => 'perm',
+        'Auto Replies' => 'auto',
+        'Email Signature' => 'sig'
+    ];
+
+    /**
      * Default values.
      */
     protected $attributes = [
@@ -162,7 +172,8 @@ class Mailbox extends Model
         return $this->belongsToMany('App\User')->as('settings')
             ->withPivot('after_send')
             ->withPivot('hide')
-            ->withPivot('mute');
+            ->withPivot('mute')
+            ->withPivot('access');
     }
 
     /**
@@ -552,6 +563,7 @@ class Mailbox extends Model
             $settings->after_send = MailboxUser::AFTER_SEND_NEXT;
             $settings->hide = false;
             $settings->mute = false;
+            $settings->access = false;
 
             return $settings;
         }
@@ -564,6 +576,7 @@ class Mailbox extends Model
         $this->after_send = $settings->after_send;
         $this->hide = $settings->hide;
         $this->mute = $settings->mute;
+        $this->access = $settings->access;
     }
 
     /**
@@ -690,7 +703,7 @@ class Mailbox extends Model
 
     public static function findOrFailWithSettings($id, $user_id)
     {
-        return Mailbox::select(['mailboxes.*', 'mailbox_user.hide', 'mailbox_user.mute'])
+        return Mailbox::select(['mailboxes.*', 'mailbox_user.hide', 'mailbox_user.mute', 'mailbox_user.access'])
                         ->where('mailboxes.id', $id)
                         ->leftJoin('mailbox_user', function ($join) use ($user_id) {
                             $join->on('mailbox_user.mailbox_id', '=', 'mailboxes.id');

--- a/app/Policies/MailboxPolicy.php
+++ b/app/Policies/MailboxPolicy.php
@@ -78,7 +78,76 @@ class MailboxPolicy
      */
     public function update(User $user, Mailbox $mailbox)
     {
-        if ($user->isAdmin()) {
+        if ($user->isAdmin() || $user->canManageMailbox($mailbox->id)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+
+    /**
+     * Determine whether the user can update the mailbox auto reply.
+     *
+     * @param \App\User    $user
+     * @param \App\Mailbox $mailbox
+     *
+     * @return mixed
+     */
+    public function updateAutoReply(User $user, Mailbox $mailbox)
+    {
+        if ($user->isAdmin() || $user->hasManageMailboxPermission($mailbox->id, 'auto')) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Determine whether the user can update the mailbox Permissions.
+     *
+     * @param \App\User    $user
+     * @param \App\Mailbox $mailbox
+     *
+     * @return mixed
+     */
+    public function updatePermissions(User $user, Mailbox $mailbox)
+    {
+        if ($user->isAdmin() || $user->hasManageMailboxPermission($mailbox->id, 'perm')) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Determine whether the user can update the mailbox Permissions.
+     *
+     * @param \App\User    $user
+     * @param \App\Mailbox $mailbox
+     *
+     * @return mixed
+     */
+    public function updateSettings(User $user, Mailbox $mailbox)
+    {
+        if ($user->isAdmin() || $user->hasManageMailboxPermission($mailbox->id, 'edit')) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Determine whether the user can update the mailbox Email Signature.
+     *
+     * @param \App\User    $user
+     * @param \App\Mailbox $mailbox
+     *
+     * @return mixed
+     */
+    public function updateEmailSignature(User $user, Mailbox $mailbox)
+    {
+        if ($user->isAdmin() || $user->hasManageMailboxPermission($mailbox->id, 'sig')) {
             return true;
         } else {
             return false;

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -52,7 +52,7 @@ class UserPolicy
      */
     public function update(User $user, User $model)
     {
-        if ($user->isAdmin() || $user->id == $model->id) {
+        if ($user->isAdmin() || $user->id == $model->id || $user->canManageMailbox($model->id)) {
             return true;
         } else {
             return false;
@@ -102,6 +102,8 @@ class UserPolicy
     public function viewMailboxMenu(User $user)
     {
         if ($user->isAdmin() || \Eventy::filter('user.can_view_mailbox_menu', false, $user)) {
+            return true;
+        } else if ($user->hasManageMailboxAccess()) {
             return true;
         } else {
             return false;

--- a/database/migrations/2020_09_18_123314_add_access_column_to_mailbox_user_table.php
+++ b/database/migrations/2020_09_18_123314_add_access_column_to_mailbox_user_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddAccessColumnToMailboxUserTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('mailbox_user', function (Blueprint $table) {
+            $table->text('access')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('mailbox_user', function (Blueprint $table) {
+            $table->dropColumn('access');
+        });
+    }
+}

--- a/resources/views/mailboxes/email_signature.blade.php
+++ b/resources/views/mailboxes/email_signature.blade.php
@@ -1,0 +1,53 @@
+@extends('layouts.app')
+
+@section('title_full', __('Edit Mailbox').' - '.$mailbox->name)
+
+@section('body_attrs')@parent data-mailbox_id="{{ $mailbox->id }}"@endsection
+
+@section('sidebar')
+    @include('partials/sidebar_menu_toggle')
+    @include('mailboxes/sidebar_menu')
+@endsection
+
+@section('content')
+    <div class="section-heading">
+        {{ __('Email Signature') }}
+    </div>
+
+    @include('partials/flash_messages')
+
+    <div class="row-container form-container">
+        <div class="row">
+            <div class="col-xs-12">
+                <form class="form-horizontal margin-top" method="POST" action="">
+                    {{ csrf_field() }}
+
+                    <div class="form-group{{ $errors->has('signature') ? ' has-error' : '' }}">
+                        <label for="signature" class="col-sm-2 control-label">{{ __('Email Signature') }}</label>
+
+                        <div class="col-md-9 signature-editor">
+                            <textarea id="signature" class="form-control" name="signature" rows="8">{{ old('signature', $mailbox->signature) }}</textarea>
+                            @include('partials/field_error', ['field'=>'signature'])
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="col-sm-6 col-sm-offset-2">
+                            <button type="submit" class="btn btn-primary">
+                                {{ __('Save') }}
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+@endsection
+
+@include('partials/editor')
+
+@section('javascript')
+    @parent
+    mailboxUpdateInit('{{ App\Mailbox::FROM_NAME_CUSTOM }}');
+@endsection

--- a/resources/views/mailboxes/permissions.blade.php
+++ b/resources/views/mailboxes/permissions.blade.php
@@ -22,7 +22,7 @@
                     <p class="block-help">{{ __('Administrators have access to all mailboxes and are not listed here.') }}</p>
                 </div>
                 <div class="col-xs-12">
-                    
+
                     {{ csrf_field() }}
 
                     <p><a href="javascript:void(0)" class="sel-all">{{ __('all') }}</a> / <a href="javascript:void(0)" class="sel-none">{{ __('none') }}</a></p>
@@ -42,30 +42,46 @@
                 </div>
 
                 <div class="col-xs-12 margin-top">
-                    <h3> {{ __('Administrators') }}:</h3>
+                    <h3> {{ __('Access Settings') }}:</h3>
                 </div>
                 <div class="col-md-11 col-lg-9">
-                    
+
                     <table class="table">
                         <tr class="table-header-nb">
                             <th>&nbsp;</th>
-                            <th class="text-center">{{ __('Hide from Assign list') }}</th>
+                            <th class="text-center"> {{ __('Hide from Assign list') }}</th>
+                            @foreach (\App\Mailbox::$USER_ACCESS_PERMISSIONS as $label=>$perm)
+                            <th class="text-center"> {{ __($label) }}</th>
+                            @endforeach
                         </tr>
                         <fieldset id="permissions-fields">
-                            @foreach ($admins as $admin)
+                            @foreach ($managers as $mailbox_user)
                                 <tr>
-                                    <td>{{ $admin->getFullName() }}</td>
-                                    <td class="text-center"><input type="checkbox" name="admins[{{ $admin->id }}][hide]" value="1" @if (!empty($admin->hide)) checked="checked" @endif></td>
+                                    <td>{{ $mailbox_user->getFullName() }}
+                                        @if ($mailbox_user->isAdmin())
+                                            ({{ __('Administrator') }})
+                                            <td class="text-center"><input type="checkbox" name="managers[{{ $mailbox_user->id }}][hide]" value="1" @if (!empty($mailbox_user->hide)) checked="checked" @endif></td>
+                                            <td class="text-center"></td>
+                                            <td class="text-center"></td>
+                                            <td class="text-center"></td>
+                                        @else
+                                            <td></td>
+                                            @foreach (\App\Mailbox::$USER_ACCESS_PERMISSIONS as $label=>$perm)
+                                            <td class="text-center"><input type="checkbox" name="managers[{{ $mailbox_user->id }}][access][{{ $perm }}]" value="{{ $perm }}" @if (!empty($mailbox_user->access) && in_array($perm, json_decode($mailbox_user->access))) checked="checked" @endif></td>
+                                            @endforeach
+                                        @endif
+
+                                    </td>
                                 </tr>
                             @endforeach
                         </fieldset>
                     </table>
                     <div class="form-group margin-top">
-                        
+
                         <button type="submit" class="btn btn-primary">
                             {{ __('Save') }}
                         </button>
-                    
+
                     </div>
                 </div>
             </form>

--- a/resources/views/mailboxes/settings_menu.blade.php
+++ b/resources/views/mailboxes/settings_menu.blade.php
@@ -1,8 +1,19 @@
 @if (Auth::user()->can('update', $mailbox))
-	<li @if (Route::currentRouteName() == 'mailboxes.update')class="active"@endif><a href="{{ route('mailboxes.update', ['id'=>$mailbox->id]) }}"><i class="glyphicon glyphicon-pencil"></i> {{ __('Edit Mailbox') }}</a></li>
-	<li @if (Route::currentRouteName() == 'mailboxes.connection' || Route::currentRouteName() == 'mailboxes.connection.incoming')class="active"@endif><a href="{{ route('mailboxes.connection', ['id'=>$mailbox->id]) }}"><i class="glyphicon glyphicon-transfer"></i> {{ __('Connection Settings') }}</a></li>
-	<li @if (Route::currentRouteName() == 'mailboxes.permissions')class="active"@endif><a href="{{ route('mailboxes.permissions', ['id'=>$mailbox->id]) }}"><i class="glyphicon glyphicon-ok"></i> {{ __('Permissions') }}</a></li>
-	<li @if (Route::currentRouteName() == 'mailboxes.auto_reply')class="active"@endif><a href="{{ route('mailboxes.auto_reply', ['id'=>$mailbox->id]) }}"><i class="glyphicon glyphicon-share"></i> {{ __('Auto Reply') }}</a></li>
+    @if (Auth::user()->isAdmin() || Auth::user()->hasManageMailboxPermission($mailbox->id, 'edit'))
+    	<li @if (Route::currentRouteName() == 'mailboxes.update')class="active"@endif><a href="{{ route('mailboxes.update', ['id'=>$mailbox->id]) }}"><i class="glyphicon glyphicon-pencil"></i> {{ __('Edit Mailbox') }}</a></li>
+    @endif
+    @if (Auth::user()->isAdmin())
+        <li @if (Route::currentRouteName() == 'mailboxes.connection' || Route::currentRouteName() == 'mailboxes.connection.incoming')class="active"@endif><a href="{{ route('mailboxes.connection', ['id'=>$mailbox->id]) }}"><i class="glyphicon glyphicon-transfer"></i> {{ __('Connection Settings') }}</a></li>
+    @endif
+    @if (Auth::user()->isAdmin() || Auth::user()->hasManageMailboxPermission($mailbox->id, 'perm'))
+        <li @if (Route::currentRouteName() == 'mailboxes.permissions')class="active"@endif><a href="{{ route('mailboxes.permissions', ['id'=>$mailbox->id]) }}"><i class="glyphicon glyphicon-ok"></i> {{ __('Permissions') }}</a></li>
+    @endif
+    @if (Auth::user()->isAdmin() || Auth::user()->hasManageMailboxPermission($mailbox->id, 'auto'))
+        <li @if (Route::currentRouteName() == 'mailboxes.auto_reply')class="active"@endif><a href="{{ route('mailboxes.auto_reply', ['id'=>$mailbox->id]) }}"><i class="glyphicon glyphicon-share"></i> {{ __('Auto Reply') }}</a></li>
+    @endif
+    @if (Auth::user()->isAdmin() || Auth::user()->hasManageMailboxPermission($mailbox->id, 'sig'))
+        <li @if (Route::currentRouteName() == 'mailboxes.email_signature')class="active"@endif><a href="{{ route('mailboxes.email_signature', ['id'=>$mailbox->id]) }}"><i class="glyphicon glyphicon-bullhorn"></i> {{ __('Email Signature') }}</a></li>
+    @endif
 @endif
 @action('mailboxes.settings.menu', $mailbox)
 @if (!empty($is_dropdown) && Auth::user()->isAdmin())

--- a/resources/views/mailboxes/update.blade.php
+++ b/resources/views/mailboxes/update.blade.php
@@ -26,8 +26,11 @@
                         <label for="name" class="col-sm-2 control-label">{{ __('Mailbox Name') }}</label>
 
                         <div class="col-sm-6">
-                            <input id="name" type="text" class="form-control input-sized" name="name" value="{{ old('name', $mailbox->name) }}" maxlength="40" required autofocus>
-
+                            @if (Auth::user()->isAdmin())
+                                <input id="name" type="text" class="form-control input-sized" name="name" value="{{ old('name', $mailbox->name) }}" maxlength="40" required autofocus>
+                            @else
+                                {{ old('name', $mailbox->name) }}
+                            @endif
                             @include('partials/field_error', ['field'=>'name'])
                         </div>
                     </div>
@@ -36,7 +39,11 @@
                         <label for="email" class="col-sm-2 control-label">{{ __('Email Address') }}</label>
 
                         <div class="col-sm-6">
+                            @if (Auth::user()->isAdmin())
                             <input id="email" type="email" class="form-control input-sized" name="email" value="{{ old('email', $mailbox->email) }}" maxlength="128" required autofocus>
+                            @else
+                                {{ old('email', $mailbox->email) }}
+                            @endif
                             @include('partials/field_error', ['field'=>'email'])
                         </div>
                     </div>
@@ -50,7 +57,7 @@
 
                                 <i class="glyphicon glyphicon-info-sign icon-info" data-toggle="popover" data-trigger="hover" data-html="true" data-placement="left"  data-content="{{ __('Aliases are other email addresses that also forward to your mailbox address. Separate each email with a comma.') }}"></i>
                             </div>
-                            
+
                             @include('partials/field_error', ['field'=>'aliases'])
                         </div>
                     </div>
@@ -64,7 +71,7 @@
 
                                 <i class="glyphicon glyphicon-info-sign icon-info" data-toggle="popover" data-trigger="hover" data-html="true" data-placement="left"  data-content="{{ __('Send a copy of all outgoing replies to specific external addresses.') }} {{ __('Separate each email with a comma.') }}"></i>
                             </div>
-                            
+
                             @include('partials/field_error', ['field'=>'auto_bcc'])
                         </div>
                     </div>
@@ -111,13 +118,13 @@
                     </div>
 
                     @action('mailbox.update.after_ticket_status', $mailbox)
-                    
+
                     {{-- Email Template option hidden until somebody needs it --}}
                     <div class="form-group{{ $errors->has('template') ? ' has-error' : '' }}" style="display:none">
                         <label for="template" class="col-sm-2 control-label">{{ __('Email Template') }} (todo)</label>
 
                         <div class="col-sm-6">
-     
+
                             <div class="controls">
                                 {{-- Afer implementing remove readonly--}}
                                 <label for="template_plain" class="radio inline plain"><input type="radio" name="template" value="{{ App\Mailbox::TEMPLATE_PLAIN }}" disabled="disabled" class="disabled" id="template_plain" @if (old('template', $mailbox->template) == App\Mailbox::TEMPLATE_PLAIN || !$mailbox->template)checked="checked"@endif> {{ __('Plain Template') }}</label>
@@ -155,17 +162,8 @@
 
                                 <i class="glyphicon glyphicon-info-sign icon-info" data-toggle="popover" data-trigger="hover" data-html="true" data-placement="left"  data-content="{{ __('This text will be added to the beginning of each email reply sent to a customer.') }}"></i>
                             </div>
-                            
+
                             @include('partials/field_error', ['field'=>'before_reply'])
-                        </div>
-                    </div>
-
-                    <div class="form-group{{ $errors->has('signature') ? ' has-error' : '' }}">
-                        <label for="signature" class="col-sm-2 control-label">{{ __('Email Signature') }}</label>
-
-                        <div class="col-md-9 signature-editor">
-                            <textarea id="signature" class="form-control" name="signature" rows="8">{{ old('signature', $mailbox->signature) }}</textarea>
-                            @include('partials/field_error', ['field'=>'signature'])
                         </div>
                     </div>
 
@@ -175,7 +173,9 @@
                                 {{ __('Save') }}
                             </button>
 
+                            @if (auth()->user()->isAdmin())
                             <a href="#" data-trigger="modal" data-modal-body="#delete_mailbox_modal" data-modal-no-footer="true" data-modal-title="{{ __('Delete the :mailbox_name mailbox?', ['mailbox_name' => $mailbox->name]) }}" data-modal-on-show="deleteMailboxModal" class="btn btn-link text-danger">{{ __('Delete mailbox') }}</a>
+                            @endif
                         </div>
                     </div>
                 </form>

--- a/routes/web.php
+++ b/routes/web.php
@@ -75,6 +75,8 @@ Route::get('/mailbox/connection-settings/{id}/incoming', 'MailboxesController@co
 Route::post('/mailbox/connection-settings/{id}/incoming', 'MailboxesController@connectionIncomingSave')->name('mailboxes.connection.incoming.save');
 Route::get('/mailbox/settings/{id}/auto-reply', 'MailboxesController@autoReply')->name('mailboxes.auto_reply');
 Route::post('/mailbox/settings/{id}/auto-reply', 'MailboxesController@autoReplySave')->name('mailboxes.auto_reply.save');
+Route::get('/mailbox/settings/{id}/email-signature', 'MailboxesController@emailSignature')->name('mailboxes.email_signature');
+Route::post('/mailbox/settings/{id}/email-signature', 'MailboxesController@emailSignatureSave')->name('mailboxes.email_signature.save');
 Route::post('/mailbox/ajax', ['uses' => 'MailboxesController@ajax', 'laroute' => true])->name('mailboxes.ajax');
 
 // Customers


### PR DESCRIPTION
Updates permissions page to edit per user permissions as defined.
Permissions stored in mailbox_user.access and defined in Mailbox ($USER_ACCESS_PERMISSIONS)
Hides pages and options without permission on templates:

- delete button
- mailbox address and name only editable by admin
- settings_menu

Added policy definitions to check permissions on each save page.
Moves email signature to own edit page (similar to Auto-Reply) to keep managers from needing to see breakable settings.


