### PR TITLE
Fix prefill_to

### DIFF
--- a/app/Http/Controllers/ConversationsController.php
+++ b/app/Http/Controllers/ConversationsController.php
@@ -323,7 +323,7 @@ class ConversationsController extends Controller
 
         $prefill_to = \App\Email::sanitizeEmail($request->get('to'));
         if ($prefill_to) {
-            $to = [$prefill_to];
+            $to = [$prefill_to => $prefill_to];
         }
 
         return view('conversations/create', [


### PR DESCRIPTION
Fixes `prefill_to` introduced in #940 and improved in 3446abd.

It must be an array with keys in order to set correctly.

https://github.com/freescout-helpdesk/freescout/blob/920690e50454af3d89454ea406c344c6b524b390/resources/views/conversations/create.blade.php#L141-L143