### PR TITLE
Fix email customer link

### DIFF
--- a/resources/views/customers/profile_snippet.blade.php
+++ b/resources/views/customers/profile_snippet.blade.php
@@ -13,13 +13,25 @@
 			@if (!empty($main_email))
 		    	@foreach ($customer->emails as $email)
 		    		@if ($email->email == $main_email)
-		            	<li class="customer-email"><a href="{{ $mailbox->url() }}/new-ticket?to={{ urlencode($email->email) }}" title="{{ __('Email customer') }}" class="contact-main">{{ $email->email }}</a></li>
+		    		    <li class="customer-email">
+		    		        @if (!empty($mailbox))
+		    		            <a href="{{ $mailbox->url() }}/new-ticket?to={{ urlencode($email->email) }}" class="contact-main">{{ $email->email }}</a>
+		    		        @else
+		    		            {{ $email->email }}
+		           	        @endif
+		           	    </li>
 		           	@endif
 		        @endforeach
 		    @endif
 		    @foreach ($customer->emails as $email)
 		    	@if (empty($main_email) || $email->email != $main_email)
-	            	<li class="customer-email"><a href="{{ $mailbox->url() }}/new-ticket?to={{ urlencode($email->email) }}" title="{{ __('Email customer') }}" class="@if (empty($main_email) && $loop->index == 0) contact-main @endif">{{ $email->email }}</a></li>
+	            	<li class="customer-email">
+	                    @if (!empty($mailbox))
+	                        <a href="{{ $mailbox->url() }}/new-ticket?to={{ urlencode($email->email) }}" class="contact-main">{{ $email->email }}</a>
+	                    @else
+	                        {{ $email->email }}
+	                    @endif
+	                </li>
 	            @endif
 	        @endforeach
 			@foreach ($customer->getPhones() as $phone)

--- a/resources/views/customers/profile_snippet.blade.php
+++ b/resources/views/customers/profile_snippet.blade.php
@@ -13,13 +13,13 @@
 			@if (!empty($main_email))
 		    	@foreach ($customer->emails as $email)
 		    		@if ($email->email == $main_email)
-		            	<li class="customer-email"><a href="/mailbox/{{ $mailbox->id }}/new-ticket?to={{ urlencode($email->email) }}" title="{{ __('Email customer') }}" class="contact-main">{{ $email->email }}</a></li>
+		            	<li class="customer-email"><a href="{{ $mailbox->url() }}/new-ticket?to={{ urlencode($email->email) }}" title="{{ __('Email customer') }}" class="contact-main">{{ $email->email }}</a></li>
 		           	@endif
 		        @endforeach
 		    @endif
 		    @foreach ($customer->emails as $email)
 		    	@if (empty($main_email) || $email->email != $main_email)
-	            	<li class="customer-email"><a href="/mailbox/{{ $mailbox->id }}/new-ticket?to={{ urlencode($email->email) }}" title="{{ __('Email customer') }}" class="@if (empty($main_email) && $loop->index == 0) contact-main @endif">{{ $email->email }}</a></li>
+	            	<li class="customer-email"><a href="{{ $mailbox->url() }}/new-ticket?to={{ urlencode($email->email) }}" title="{{ __('Email customer') }}" class="@if (empty($main_email) && $loop->index == 0) contact-main @endif">{{ $email->email }}</a></li>
 	            @endif
 	        @endforeach
 			@foreach ($customer->getPhones() as $phone)

--- a/resources/views/customers/profile_snippet.blade.php
+++ b/resources/views/customers/profile_snippet.blade.php
@@ -13,13 +13,13 @@
 			@if (!empty($main_email))
 		    	@foreach ($customer->emails as $email)
 		    		@if ($email->email == $main_email)
-		            	<li class="customer-email"><a href="#" title="{{ __('Email customer') }}" class="contact-main">{{ $email->email }}</a></li>
+		            	<li class="customer-email"><a href="/mailbox/{{ $mailbox->id }}/new-ticket?to={{ urlencode($email->email) }}" title="{{ __('Email customer') }}" class="contact-main">{{ $email->email }}</a></li>
 		           	@endif
 		        @endforeach
 		    @endif
 		    @foreach ($customer->emails as $email)
 		    	@if (empty($main_email) || $email->email != $main_email)
-	            	<li class="customer-email"><a href="#" title="{{ __('Email customer') }}" class="@if (empty($main_email) && $loop->index == 0) contact-main @endif">{{ $email->email }}</a></li>
+	            	<li class="customer-email"><a href="/mailbox/{{ $mailbox->id }}/new-ticket?to={{ urlencode($email->email) }}" title="{{ __('Email customer') }}" class="@if (empty($main_email) && $loop->index == 0) contact-main @endif">{{ $email->email }}</a></li>
 	            @endif
 	        @endforeach
 			@foreach ($customer->getPhones() as $phone)


### PR DESCRIPTION
We noticed the user email link in sidebar goes nowhere:

![freescout-missing-email-customer-link](https://user-images.githubusercontent.com/1180948/120796782-8761ad80-c53b-11eb-8e8b-dd2b3e947278.png)

It only had `href="#"` on it, so we fixed that to go to:

```
{{ $mailbox->url() }}/new-ticket?to={{ urlencode($email->email) }}
```

That actually does give you the new ticket screen with the email address pre-filled.