### PR TITLE
Customer email copy link

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1202,6 +1202,9 @@ a h4 {
     margin: 0;
     padding: 0;
 }
+.customer-contacts li {
+    display: block;
+}
 .customer-contacts li,
 .customer-contacts li a {
     /*overflow: hidden;
@@ -1209,7 +1212,6 @@ a h4 {
     word-wrap: break-word;
     overflow-wrap: break-word;
     /*white-space: nowrap;*/
-    display: block;
     margin-top: 2px;
     color: #93a1af;
     line-height: 16px;

--- a/resources/views/customers/profile_snippet.blade.php
+++ b/resources/views/customers/profile_snippet.blade.php
@@ -13,13 +13,13 @@
 			@if (!empty($main_email))
 		    	@foreach ($customer->emails as $email)
 		    		@if ($email->email == $main_email)
-		            	<li class="customer-email"><a href="#" title="{{ __('Email customer') }}" class="contact-main">{{ $email->email }}</a></li>
+		            	<li class="customer-email"><a href="#" title="{{ __('Email customer') }}" class="contact-main">{{ $email->email }}</a> <a href="javascript:navigator.clipboard.writeText('{{ $email->email }}')" class="glyphicon glyphicon-file" title="Copy email address to clipboard"></a></li>
 		           	@endif
 		        @endforeach
 		    @endif
 		    @foreach ($customer->emails as $email)
 		    	@if (empty($main_email) || $email->email != $main_email)
-	            	<li class="customer-email"><a href="#" title="{{ __('Email customer') }}" class="@if (empty($main_email) && $loop->index == 0) contact-main @endif">{{ $email->email }}</a></li>
+	            	<li class="customer-email"><a href="#" title="{{ __('Email customer') }}" class="@if (empty($main_email) && $loop->index == 0) contact-main @endif">{{ $email->email }}</a> <a href="javascript:navigator.clipboard.writeText('{{ $email->email }}')" class="glyphicon glyphicon-file" title="Copy email address to clipboard"></a></li>
 	            @endif
 	        @endforeach
 			@foreach ($customer->getPhones() as $phone)


### PR DESCRIPTION
We found we often need to copy the customer email address. This addition of a simple link to copy the email address to clipboard is very handy to us and I believe other users will like it too.
![freescout-customer-email-copy-link](https://user-images.githubusercontent.com/1180948/120800647-76676b00-c540-11eb-89f9-d5a73621efa8.png)
