### PR TITLE
Update fzaninotto/faker to fix PHP >= 7.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require-dev": {
         "barryvdh/laravel-debugbar": "v3.2.0",
         "filp/whoops": "2.2.0",
-        "fzaninotto/faker": "v1.7.1",
+        "fzaninotto/faker": "~v1.9.2",
         "mockery/mockery": "1.1.0",
         "phpunit/phpunit": "6.5.8",
 


### PR DESCRIPTION
Update fzaninotto/faker to fix issue due to changes with implode() in PHP >= 7.4 (see fzaninotto/faker#1748). Otherwise, DB seeding is broken on >= PHP 7.4:

<img width="497" alt="Screenshot 2021-08-10 at 06 10 21" src="https://user-images.githubusercontent.com/2807620/128811463-9fe731ac-2caf-44c4-ad1b-9b9390687068.png">
