### PR TITLE
Made it possible to track threads based on a ticket number in the sub…

### DIFF
--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -309,6 +309,22 @@ class FetchEmails extends Command
                 }
             }
 
+            //Try to get first mesage ID in thread from conversation ID in subject to get some coherence in auto responders that do not send proper headers.
+            if (!$prev_message_id) {
+                $subject = $message->getSubject();
+                $conversation_id = \MailHelper::fetchMessageTicketNumberValue($subject);
+                if (!is_null($conversation_id)) {
+                    $this->line('['.date('Y-m-d H:i:s').'] Using conversation_id ' . $conversation_id . ' matched from subject');
+                    $thread = Thread::where('conversation_id', $conversation_id)->first();
+                    if (is_null($thread)) {
+                        $this->logError('No threads with conversation_id ' . $conversation_id . " found.");
+                    }
+                    else {
+                        $prev_message_id = $thread->message_id;
+                    }
+                }
+            }
+
             // Bounce detection.
             $bounced_message_id = null;
             if ($message->hasAttachments()) {

--- a/app/Misc/Mail.php
+++ b/app/Misc/Mail.php
@@ -438,7 +438,7 @@ class Mail
     /**
      * Fetch Message-ID from incoming email body.
      *
-     * @param [type] $message_id [description]
+     * @param [type] $body [description]
      *
      * @return [type] [description]
      */
@@ -452,6 +452,32 @@ class Mail
 
         return '';
     }
+
+    /**
+     * Fetch Ticket Number from incoming email subject.
+     *
+     * @param [type] $subject [description]
+     *
+     * @return [type] [description]
+     */
+    public static function fetchMessageTicketNumberValue($subject)
+    {
+        $prefix = \Config::get('mail.prefix', "[#");
+        $suffix = \Config::get('mail.suffix', "] ");
+        $trustsubject = \Config::get('mail.trustsubject', false);
+
+        if ($trustsubject) {
+            preg_match('/' . preg_quote($prefix) . '([0-9]+)' . preg_quote($suffix) . '/', $subject, $matches);
+            if (!empty($matches[1])) {
+                // Return first found ticket number.
+                return $matches[1];
+            }
+        }
+
+        return NULL;
+    }
+
+
 
     /**
      * Detect autoresponder by headers.

--- a/config/mail.php
+++ b/config/mail.php
@@ -120,4 +120,8 @@ return [
         ],
     ],
 
+    'prefix' => env('TICKETNUMBER_PREFIX', "[#"),
+    'suffix' => env('TICKETNUMBER_SUFFIX', "] "),
+    'trustsubject' => env('TICKETNUMBER_TRUSTSUBJECT', false),
+
 ];


### PR DESCRIPTION
…ject.

TicketNumber module required and I also have a small update for this one.
Added .env settings for:
TICKETNUMBER_PREFIX defaulting to "[#"
TICKETNUMBER_SUfFIX defaulting to "] "
TICKETNUMBER_TRUSTSUBJECT defaulting to false (this will toggle this functionality on and off)
This fix will be great for everyone who need to forward tickets to external helpdesks that are not always adhering to standard use of In-Reply-To and Referenced headers.

If the subject matches a conversation_id it will use the first thread in that conversation as its parent messageid

Also have an update of the module TicketNumber that would make the prefix and suffix customizable with the same .env settings as above.