### PR TITLE
Fixing error about: "unable to run isDraft() on null".

### DIFF
--- a/app/Jobs/SendReplyToCustomer.php
+++ b/app/Jobs/SendReplyToCustomer.php
@@ -94,6 +94,9 @@ class SendReplyToCustomer implements ShouldQueue
         $new = false;
         $headers = [];
         $this->last_thread = $this->threads->first();
+        if ($this->last_thread === null) {
+            return;
+        }
         $last_customer_thread = null;
 
         // If thread is draft, it means it has been undone


### PR DESCRIPTION
<img width="1059" alt="Screenshot 2021-10-13 at 21 44 03" src="https://user-images.githubusercontent.com/32955832/137209913-8d452ce1-106e-4586-9fdc-9a959ed009f9.png">

This error is sometimes preventing the system from sending any confirmation. This fix solves it, however I have not a very solid reproduction scenario yet.