### PR TITLE
Fixing error about: "unable to run isDraft() on null".

### DIFF
--- a/app/Jobs/SendReplyToCustomer.php
+++ b/app/Jobs/SendReplyToCustomer.php
@@ -94,6 +94,9 @@ class SendReplyToCustomer implements ShouldQueue
         $new = false;
         $headers = [];
         $this->last_thread = $this->threads->first();
+        if ($this->last_thread === null) {
+            return;
+        }
         $last_customer_thread = null;
 
         // If thread is draft, it means it has been undone


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32955832/137318845-935c7671-65c4-4429-9faf-62503aee5743.png)

This error is sometimes preventing the system from sending any confirmation. This fix solves it, however I have not a very solid reproduction scenario yet.