### PR TITLE
Added side layout hook on the New Conversation page

### DIFF
--- a/resources/views/conversations/create.blade.php
+++ b/resources/views/conversations/create.blade.php
@@ -44,7 +44,9 @@
 
             </div>
         </div>
-        <div id="conv-layout-customer"></div>
+        <div id="conv-layout-customer">
+            @action('conversation.new_conv_layout_side', $conversation, $mailbox)
+        </div>
         <div id="conv-layout-main" class="conv-new-form">
             <div class="conv-block">
                 <div class="row">


### PR DESCRIPTION
This hook will enable modules to display their own views on the New conversation page on the right side of the page, similar to the View Conversation page.

