### PR TITLE
Added side layout hook on the New Conversation page

### DIFF
--- a/resources/views/conversations/create.blade.php
+++ b/resources/views/conversations/create.blade.php
@@ -45,7 +45,7 @@
             </div>
         </div>
         <div id="conv-layout-customer">
-            @action('conversation.new_conv_layout_side', $conversation, $mailbox)
+            @action('conversation.new.customer_sidebar', $conversation, $mailbox)
         </div>
         <div id="conv-layout-main" class="conv-new-form">
             <div class="conv-block">


### PR DESCRIPTION
This hook will enable modules to display their own views on the New conversation page on the right side of the page, similar to the View Conversation page.