### PR TITLE
Added hooks for custom fetch email providers

### DIFF
--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -75,8 +75,8 @@ class FetchEmails extends Command
 
         $this->extra_import = [];
 
-        // Get active mailboxes
-        $this->mailboxes = Mailbox::get();
+        // Get active mailboxes with the default in_protocols
+        $this->mailboxes = Mailbox::whereIn('in_protocol', array_keys(Mailbox::$in_protocols))->get();
 
         foreach ($this->mailboxes as $mailbox) {
             if (!$mailbox->isInActive()) {

--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -75,8 +75,12 @@ class FetchEmails extends Command
 
         $this->extra_import = [];
 
-        // Get active mailboxes with the default in_protocols
-        $this->mailboxes = Mailbox::whereIn('in_protocol', array_keys(Mailbox::$in_protocols))->get();
+        if (Mailbox::getInProtocols() === Mailbox::$in_protocols) {
+            $this->mailboxes = Mailbox::get();
+        } else {
+            // Get active mailboxes with the default in_protocols
+            $this->mailboxes = Mailbox::whereIn('in_protocol', array_keys(Mailbox::$in_protocols))->get();
+        }
 
         foreach ($this->mailboxes as $mailbox) {
             if (!$mailbox->isInActive()) {

--- a/app/Http/Controllers/MailboxesController.php
+++ b/app/Http/Controllers/MailboxesController.php
@@ -628,6 +628,8 @@ class MailboxesController extends Controller
                     $response['msg'] = __('Not enough permissions');
                 }
 
+                $response = \Eventy::filter('mailbox.fetch_test', $response, $mailbox);
+
                 // Check if outgoing port is open.
                 if (!$response['msg']) {
                     $test_result = \Helper::checkPort($mailbox->in_server, $mailbox->in_port);

--- a/app/Http/Controllers/MailboxesController.php
+++ b/app/Http/Controllers/MailboxesController.php
@@ -630,15 +630,17 @@ class MailboxesController extends Controller
 
                 $response = \Eventy::filter('mailbox.fetch_test', $response, $mailbox);
 
+                $tested = (isset($response['tested']) && $response['tested'] === true);
+
                 // Check if outgoing port is open.
-                if (!$response['msg']) {
+                if (!$response['msg'] && !$tested) {
                     $test_result = \Helper::checkPort($mailbox->in_server, $mailbox->in_port);
                     if (!$test_result) {
                         $response['msg'] = __(':host is not available on :port port. Make sure that :host address is correct and that outgoing port :port on YOUR server is open.', ['host' => '<strong>'.$mailbox->in_server.'</strong>', 'port' => '<strong>'.$mailbox->in_port.'</strong>']);
                     }
                 }
 
-                if (!$response['msg']) {
+                if (!$response['msg'] && !$tested) {
                     $test_result = false;
 
                     try {
@@ -652,7 +654,7 @@ class MailboxesController extends Controller
                     }
                 }
 
-                if (!$response['msg']) {
+                if (!$response['msg'] && !$tested) {
                     $response['status'] = 'success';
                 }
                 break;

--- a/app/Mailbox.php
+++ b/app/Mailbox.php
@@ -406,6 +406,12 @@ class Mailbox extends Model
      */
     public function isInActive()
     {
+        $in_active = \Eventy::filter('mailbox.in_active', null, $this);
+
+        if (is_bool($in_active)) {
+            return $in_active;
+        }
+
         if ($this->in_protocol && $this->in_server && $this->in_port && $this->in_username && $this->in_password) {
             return true;
         } else {
@@ -595,7 +601,32 @@ class Mailbox extends Model
      */
     public function getInProtocolName()
     {
-        return self::$in_protocols[$this->in_protocol] ?? '';
+        return $this->getInProtocols()[$this->in_protocol] ?? '';
+    }
+
+    /**
+     * Get incoming protocol display name for the UI.
+     *
+     * @return array
+     */
+    public static function getInProtocolDisplayNames()
+    {
+        $display_names = self::$in_protocols;
+
+        $display_names[self::IN_PROTOCOL_IMAP] = 'IMAP';
+        $display_names[self::IN_PROTOCOL_POP3] = 'POP3';
+
+        return \Eventy::filter('mailbox.in_protocols.display_names', $display_names);
+    }
+
+    /**
+     * Get available incoming protocols.
+     *
+     * @return array
+     */
+    public static function getInProtocols()
+    {
+        return \Eventy::filter('mailbox.in_protocols', self::$in_protocols);
     }
 
     /**

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -622,6 +622,27 @@ function mailboxConnectionInit(out_method_smtp)
 function mailboxConnectionIncomingInit()
 {
 	$(document).ready(function(){
+        let changeProtocol = function() {
+            let in_protocol = $('[name="in_protocol"]').val();
+
+            // Only show default connection settings for IMAP/POP3.
+            $('[data-in-protocol]').hide();
+
+            let specific = $('[data-in-protocol="' + in_protocol + '"]');
+
+            if (specific.length >= 1) {
+                specific.show();
+            } else {
+                $('[data-in-protocol="default"]').show();
+            }
+        };
+
+        $('[name="in_protocol"]').on('change', function(event) {
+            changeProtocol();
+        });
+
+        changeProtocol();
+
 	    $('#check-connection').click(function(event) {
 	    	var button = $(this);
 	    	button.button('loading');

--- a/resources/views/mailboxes/connection_incoming.blade.php
+++ b/resources/views/mailboxes/connection_incoming.blade.php
@@ -58,8 +58,9 @@
                         <div class="col-sm-6">
                             <div class="flexy">
                                 <select id="in_protocol" class="form-control input-sized" name="in_protocol" required autofocus>
-                                    <option value="{{ App\Mailbox::IN_PROTOCOL_IMAP }}" @if (old('in_protocol', $mailbox->in_protocol) == App\Mailbox::IN_PROTOCOL_IMAP)selected="selected"@endif>IMAP</option>
-                                    <option value="{{ App\Mailbox::IN_PROTOCOL_POP3 }}" @if (old('in_protocol', $mailbox->in_protocol) == App\Mailbox::IN_PROTOCOL_POP3)selected="selected"@endif>POP3</option>
+                                    @foreach($mailbox->getInProtocolDisplayNames() as $id => $name)
+                                        <option value="{{$id}}" @if (old('in_protocol', $mailbox->in_protocol) == $id)selected="selected"@endif>{{$name}}</option>
+                                    @endforeach
                                 </select>
                             </div>
 
@@ -67,108 +68,121 @@
                         </div>
                     </div>
 
-                    <div class="form-group{{ $errors->has('in_server') ? ' has-error' : '' }}">
-                        <label for="in_server" class="col-sm-2 control-label">{{ __('Server') }}</label>
-
-                        <div class="col-sm-6">
-                            <input id="in_server" type="text" class="form-control input-sized" name="in_server" value="{{ old('in_server', $mailbox->in_server) }}" maxlength="255">
-
-                            {{--@include('partials/field_error', ['field'=>'in_server'])--}}
-                        </div>
-                    </div>
-
-                    <div class="form-group{{ $errors->has('in_port') ? ' has-error' : '' }}">
-                        <label for="in_port" class="col-sm-2 control-label">{{ __('Port') }}</label>
-
-                        <div class="col-sm-6">
-                            <input id="in_port" type="number" class="form-control input-sized" name="in_port" value="{{ old('in_port', $mailbox->in_port) }}" maxlength="5" required autofocus>
-
-                            {{--@include('partials/field_error', ['field'=>'in_port'])--}}
-                        </div>
-                    </div>
-
-                    <div class="form-group{{ $errors->has('in_username') ? ' has-error' : '' }}">
-                        <label for="in_username" class="col-sm-2 control-label">{{ __('Username') }}</label>
-
-                        <div class="col-sm-6">
-                            <input id="in_username" type="text" class="form-control input-sized" name="in_username" value="{{ old('in_username', $mailbox->in_username) }}" maxlength="100" {{-- This added to prevent autocomplete in Chrome --}}autocomplete="new-password">
-
-                            {{--@include('partials/field_error', ['field'=>'in_username'])--}}
-                        </div>
-                    </div>
-
-                    <div class="form-group{{ $errors->has('in_password') ? ' has-error' : '' }}">
-                        <label for="in_password" class="col-sm-2 control-label">{{ __('Password') }}</label>
-
-                        <div class="col-sm-6">
-                            <input id="in_password" type="password" class="form-control input-sized" name="in_password" value="{{ old('in_password', $mailbox->inPasswordSafe()) }}" maxlength="255" {{-- This added to prevent autocomplete in Chrome --}}autocomplete="new-password">
-
-                            {{--@include('partials/field_error', ['field'=>'in_password'])--}}
-                        </div>
-                    </div>
-
-                    <div class="form-group{{ $errors->has('in_encryption') ? ' has-error' : '' }}">
-                        <label for="in_encryption" class="col-sm-2 control-label">{{ __('Encryption') }}</label>
-
-                        <div class="col-sm-6">
-                            <select id="in_encryption" class="form-control input-sized" name="in_encryption" @if ($mailbox->out_method == App\Mailbox::OUT_METHOD_SMTP) required @endif autofocus>
-                                <option value="{{ App\Mailbox::IN_ENCRYPTION_NONE }}" @if (old('in_encryption', $mailbox->in_encryption) == App\Mailbox::IN_ENCRYPTION_NONE)selected="selected"@endif>{{ __('None') }}</option>
-                                <option value="{{ App\Mailbox::IN_ENCRYPTION_SSL }}" @if (old('in_encryption', $mailbox->in_encryption) == App\Mailbox::IN_ENCRYPTION_SSL)selected="selected"@endif>SSL</option>
-                                <option value="{{ App\Mailbox::IN_ENCRYPTION_TLS }}" @if (old('in_encryption', $mailbox->in_encryption) == App\Mailbox::IN_ENCRYPTION_TLS)selected="selected"@endif>TLS</option>
-                            </select>
-
-                            @include('partials/field_error', ['field'=>'in_encryption'])
-                        </div>
-                    </div>
-
-                    <div class="form-group{{ $errors->has('in_imap_folders') ? ' has-error' : '' }}">
-                        <label for="in_imap_folders" class="col-sm-2 control-label">{{ __('IMAP Folders') }}</label>
-
-                        <div class="col-sm-6 flexy">
-                            <select id="in_imap_folders" class="form-control input-sized" name="in_imap_folders[]" multiple>
-                                @foreach ($mailbox->getInImapFolders() as $imap_folder)
-                                    <option value="{{ $imap_folder }}" selected="selected">{{ $imap_folder }}</option>
-                                @endforeach
-                            </select>
-
-                            <a href="#" class="btn btn-link btn-sm" data-toggle="tooltip" title="{{ __('Retrieve a list of available IMAP folders from the server') }}" id="retrieve-imap-folders" data-loading-text="{{ __('Retrieving') }}…">{{ __('Get folders') }}</a>
-
-                            @include('partials/field_error', ['field'=>'in_imap_folders'])
-                        </div>
-                    </div>
-
-                    <div class="form-group{{ $errors->has('in_validate_cert') ? ' has-error' : '' }}">
-                        <label for="in_validate_cert" class="col-sm-2 control-label">{{ __('Validate Certificate') }}</label>
-
-                        <div class="col-sm-6">
-                            <div class="controls">
-                                <div class="onoffswitch-wrap">
-                                    <div class="onoffswitch">
-                                        <input type="checkbox" name="in_validate_cert" value="1" id="in_validate_cert" class="onoffswitch-checkbox" @if (old('in_validate_cert', $mailbox->in_validate_cert))checked="checked"@endif >
-                                        <label class="onoffswitch-label" for="in_validate_cert"></label>
-                                    </div>
-
-                                    <i class="glyphicon glyphicon-info-sign icon-info icon-info-inline" data-toggle="popover" data-trigger="hover" data-placement="top" data-content="{{ __('Disable certificate validation if receiving "Certificate failure" error.') }}"></i>
-                                </div>
-                            </div>
-
-                            @include('partials/field_error', ['field'=>'in_validate_cert'])
-
-                            <div class="form-help">{!! __("Make sure to save settings before checking connection.") !!}</div>
-                        </div>
-                    </div>
-
-                    <div>
-                        <div class="form-group">
-                            <label for="imap_sent_folder" class="col-sm-2 control-label">{{ __('IMAP Folder To Save Outgoing Replies') }}</label>
+                    <div data-in-protocol="default" style="display: none;">
+                        <div class="form-group{{ $errors->has('in_server') ? ' has-error' : '' }}">
+                            <label for="in_server" class="col-sm-2 control-label">{{ __('Server') }}</label>
 
                             <div class="col-sm-6">
-                                <input id="imap_sent_folder" type="text" class="form-control input-sized" name="imap_sent_folder" value="{{ old('imap_sent_folder', $mailbox->imap_sent_folder) }}" maxlength="255" placeholder="Sent">
-                                <div class="form-help">{!! __("Enter IMAP folder name to save outgoing replies if your mail service provider does not do it automatically (Gmail does it), otherwise leave it blank.") !!}</div>
+                                <input id="in_server" type="text" class="form-control input-sized" name="in_server" value="{{ old('in_server', $mailbox->in_server) }}" maxlength="255">
+
+                                {{--@include('partials/field_error', ['field'=>'in_server'])--}}
                             </div>
                         </div>
-                        <hr/>
+
+                        <div class="form-group{{ $errors->has('in_port') ? ' has-error' : '' }}">
+                            <label for="in_port" class="col-sm-2 control-label">{{ __('Port') }}</label>
+
+                            <div class="col-sm-6">
+                                <input id="in_port" type="number" class="form-control input-sized" name="in_port" value="{{ old('in_port', $mailbox->in_port) }}" maxlength="5" required autofocus>
+
+                                {{--@include('partials/field_error', ['field'=>'in_port'])--}}
+                            </div>
+                        </div>
+
+                        <div class="form-group{{ $errors->has('in_username') ? ' has-error' : '' }}">
+                            <label for="in_username" class="col-sm-2 control-label">{{ __('Username') }}</label>
+
+                            <div class="col-sm-6">
+                                <input id="in_username" type="text" class="form-control input-sized" name="in_username" value="{{ old('in_username', $mailbox->in_username) }}" maxlength="100" {{-- This added to prevent autocomplete in Chrome --}}autocomplete="new-password">
+
+                                {{--@include('partials/field_error', ['field'=>'in_username'])--}}
+                            </div>
+                        </div>
+
+                        <div class="form-group{{ $errors->has('in_password') ? ' has-error' : '' }}">
+                            <label for="in_password" class="col-sm-2 control-label">{{ __('Password') }}</label>
+
+                            <div class="col-sm-6">
+                                <input id="in_password" type="password" class="form-control input-sized" name="in_password" value="{{ old('in_password', $mailbox->inPasswordSafe()) }}" maxlength="255" {{-- This added to prevent autocomplete in Chrome --}}autocomplete="new-password">
+
+                                {{--@include('partials/field_error', ['field'=>'in_password'])--}}
+                            </div>
+                        </div>
+
+                        <div class="form-group{{ $errors->has('in_encryption') ? ' has-error' : '' }}">
+                            <label for="in_encryption" class="col-sm-2 control-label">{{ __('Encryption') }}</label>
+
+                            <div class="col-sm-6">
+                                <select id="in_encryption" class="form-control input-sized" name="in_encryption" @if ($mailbox->out_method == App\Mailbox::OUT_METHOD_SMTP) required @endif autofocus>
+                                    <option value="{{ App\Mailbox::IN_ENCRYPTION_NONE }}" @if (old('in_encryption', $mailbox->in_encryption) == App\Mailbox::IN_ENCRYPTION_NONE)selected="selected"@endif>{{ __('None') }}</option>
+                                    <option value="{{ App\Mailbox::IN_ENCRYPTION_SSL }}" @if (old('in_encryption', $mailbox->in_encryption) == App\Mailbox::IN_ENCRYPTION_SSL)selected="selected"@endif>SSL</option>
+                                    <option value="{{ App\Mailbox::IN_ENCRYPTION_TLS }}" @if (old('in_encryption', $mailbox->in_encryption) == App\Mailbox::IN_ENCRYPTION_TLS)selected="selected"@endif>TLS</option>
+                                </select>
+
+                                @include('partials/field_error', ['field'=>'in_encryption'])
+                            </div>
+                        </div>
+
+                        <div class="form-group{{ $errors->has('in_imap_folders') ? ' has-error' : '' }}">
+                            <label for="in_imap_folders" class="col-sm-2 control-label">{{ __('IMAP Folders') }}</label>
+
+                            <div class="col-sm-6 flexy">
+                                <select id="in_imap_folders" class="form-control input-sized" name="in_imap_folders[]" multiple>
+                                    @foreach ($mailbox->getInImapFolders() as $imap_folder)
+                                        <option value="{{ $imap_folder }}" selected="selected">{{ $imap_folder }}</option>
+                                    @endforeach
+                                </select>
+
+                                <a href="#" class="btn btn-link btn-sm" data-toggle="tooltip" title="{{ __('Retrieve a list of available IMAP folders from the server') }}" id="retrieve-imap-folders" data-loading-text="{{ __('Retrieving') }}…">{{ __('Get folders') }}</a>
+
+                                @include('partials/field_error', ['field'=>'in_imap_folders'])
+                            </div>
+                        </div>
+
+                        <div class="form-group{{ $errors->has('in_validate_cert') ? ' has-error' : '' }}">
+                            <label for="in_validate_cert" class="col-sm-2 control-label">{{ __('Validate Certificate') }}</label>
+
+                            <div class="col-sm-6">
+                                <div class="controls">
+                                    <div class="onoffswitch-wrap">
+                                        <div class="onoffswitch">
+                                            <input type="checkbox" name="in_validate_cert" value="1" id="in_validate_cert" class="onoffswitch-checkbox" @if (old('in_validate_cert', $mailbox->in_validate_cert))checked="checked"@endif >
+                                            <label class="onoffswitch-label" for="in_validate_cert"></label>
+                                        </div>
+
+                                        <i class="glyphicon glyphicon-info-sign icon-info icon-info-inline" data-toggle="popover" data-trigger="hover" data-placement="top" data-content="{{ __('Disable certificate validation if receiving "Certificate failure" error.') }}"></i>
+                                    </div>
+                                </div>
+
+                                @include('partials/field_error', ['field'=>'in_validate_cert'])
+
+                                <div class="form-help">{!! __("Make sure to save settings before checking connection.") !!}</div>
+                            </div>
+                        </div>
+
+                        <div>
+                            <div class="form-group">
+                                <label for="imap_sent_folder" class="col-sm-2 control-label">{{ __('IMAP Folder To Save Outgoing Replies') }}</label>
+
+                                <div class="col-sm-6">
+                                    <input id="imap_sent_folder" type="text" class="form-control input-sized" name="imap_sent_folder" value="{{ old('imap_sent_folder', $mailbox->imap_sent_folder) }}" maxlength="255" placeholder="Sent">
+                                    <div class="form-help">{!! __("Enter IMAP folder name to save outgoing replies if your mail service provider does not do it automatically (Gmail does it), otherwise leave it blank.") !!}</div>
+                                </div>
+                            </div>
+                            <hr/>
+                        </div>
                     </div>
+
+                    @foreach($mailbox->getInProtocols() as $key => $name)
+                        {{-- Skip the default protocols --}}
+                        @if(isset(\App\Mailbox::$in_protocols[$key]))
+                            @continue
+                        @endif
+
+                        <div data-in-protocol="{{$key}}" style="display: none;">
+                            @include(\Eventy::filter('mailbox.connection_incoming.settings', null, $key, $name))
+                        </div>
+                    @endforeach
 
                     <div class="form-group margin-top-2">
                         <div class="col-sm-6 col-sm-offset-2">

--- a/resources/views/mailboxes/connection_incoming.blade.php
+++ b/resources/views/mailboxes/connection_incoming.blade.php
@@ -68,7 +68,7 @@
                         </div>
                     </div>
 
-                    <div data-in-protocol="default" style="display: none;">
+                    <div data-in-protocol="default">
                         <div class="form-group{{ $errors->has('in_server') ? ' has-error' : '' }}">
                             <label for="in_server" class="col-sm-2 control-label">{{ __('Server') }}</label>
 

--- a/resources/views/mailboxes/connection_incoming.blade.php
+++ b/resources/views/mailboxes/connection_incoming.blade.php
@@ -173,16 +173,7 @@
                         </div>
                     </div>
 
-                    @foreach($mailbox->getInProtocols() as $key => $name)
-                        {{-- Skip the default protocols --}}
-                        @if(isset(\App\Mailbox::$in_protocols[$key]))
-                            @continue
-                        @endif
-
-                        <div data-in-protocol="{{$key}}" style="display: none;">
-                            @include(\Eventy::filter('mailbox.connection_incoming.settings', null, $key, $name))
-                        </div>
-                    @endforeach
+                    @action('mailbox.connection_incoming.after_default_settings', $mailbox)
 
                     <div class="form-group margin-top-2">
                         <div class="col-sm-6 col-sm-offset-2">


### PR DESCRIPTION
This allows us to create custom importers for e-mail. It will use the FetchEmails class to add the e-mails by "simulating" the Message and Attachment classes. An example for Postal, [here](https://github.com/Wouter0100/freescout-postal/).

It would also be possible to use this for example for AWS SES Incoming emails and other e-mail providers providing incoming e-mail abilities.

No behaviour changed by default.

https://user-images.githubusercontent.com/864520/146613993-d801d2d6-bb89-4205-912e-f6cc17c4e205.mp4


