### PR TITLE
Add ability to pass config to Html2Text

### DIFF
--- a/app/Misc/Helper.php
+++ b/app/Misc/Helper.php
@@ -979,7 +979,7 @@ class Helper
      *
      * @param [type] $text [description]
      */
-    public static function htmlToText($text, $embed_images = false)
+    public static function htmlToText($text, $embed_images = false, $options = array())
     {
         // Process blockquotes.
         $text = str_ireplace('<blockquote>', '<div>', $text);
@@ -989,7 +989,7 @@ class Helper
             // Replace embedded images with their urls.
             $text = preg_replace( '/<img\b[^>]*src=\"([^>"]+)\"[^>]*>/i', "<div>$1</div>", $text);
         }
-        return (new \Html2Text\Html2Text($text))->getText();
+        return (new \Html2Text\Html2Text($text, $options))->getText();
     }
 
     /**

--- a/app/Thread.php
+++ b/app/Thread.php
@@ -293,9 +293,9 @@ class Thread extends Model
     /**
      * Convert body to plain text.
      */
-    public function getBodyAsText()
+    public function getBodyAsText($options = array())
     {
-        return \Helper::htmlToText($this->body, true);
+        return \Helper::htmlToText($this->body, true, $options);
     }
 
     public function getBodyWithFormatedLinks(string $body = '') :string


### PR DESCRIPTION
Currently, when using `$thread->getBodyAsText()` as is done in the Twitter module, [there is no way](https://github.com/freescout-helpdesk/freescout/blob/dist/app/Thread.php#L298) to [configure the underlying library](https://github.com/freescout-helpdesk/freescout/blob/f4924c3140439365d62802d1ee6697ed3bea59d2/app/Misc/Helper.php#L992) of `Html2Text`. This ability is important if you want to remove word wrapping. [The default wrapping max length](https://github.com/freescout-helpdesk/freescout/blob/f4924c3140439365d62802d1ee6697ed3bea59d2/vendor/html2text/html2text/src/Html2Text.php#L217-L219) in `Html2Text` is 70. This looks horrible in a Twitter DM when newlines are added every 70 characters. This PR adds the ability to pass a config array to `getBodyAsText` that [will make it down to `Html2Text`](https://github.com/freescout-helpdesk/freescout/blob/f4924c3140439365d62802d1ee6697ed3bea59d2/vendor/html2text/html2text/src/Html2Text.php#L232). This would allow [the configuration of word wrapping](https://github.com/freescout-helpdesk/freescout/blob/f4924c3140439365d62802d1ee6697ed3bea59d2/vendor/html2text/html2text/src/Html2Text.php#L389-L391), including removing the wrapping entirely. This would look like the following:

```php
$text = $thread->getBodyAsText(array('width' => 0));
```