### PR TITLE
Added Conversations sorting by subject, Number, Creation Date in Mailbox view page

### DIFF
--- a/app/Http/Controllers/ConversationsController.php
+++ b/app/Http/Controllers/ConversationsController.php
@@ -2244,6 +2244,21 @@ class ConversationsController extends Controller
         
         if (!$response['msg']) {
             $query_conversations = Conversation::getQueryByFolder($folder, $user->id);
+            if (
+                !empty($request->sortBy) && !empty($request->order) &&
+                in_array($request->sortBy, ['subject', 'number', 'created_at']) &&
+                in_array($request->order, ['asc', 'desc'])
+            )
+            {
+                $sort_by = $request->sortBy;
+                $order = $request->order;
+                $query_conversations = $query_conversations->orderBy($request->sortBy, $request->order);
+            }
+            else {
+                $sort_by = 'created_at';
+                $order = 'asc';
+            }
+
             $conversations = $folder->queryAddOrderBy($query_conversations)->paginate(Conversation::DEFAULT_LIST_SIZE, ['*'], 'page', $request->page);
         }
 
@@ -2252,6 +2267,8 @@ class ConversationsController extends Controller
         $response['html'] = view('conversations/conversations_table', [
             'folder'        => $folder,
             'conversations' => $conversations,
+            'sort_by'       => $sort_by,
+            'order'         => $order
         ])->render();
 
         return $response;

--- a/app/Http/Controllers/MailboxesController.php
+++ b/app/Http/Controllers/MailboxesController.php
@@ -449,6 +449,21 @@ class MailboxesController extends Controller
         $this->authorize('view', $folder);
 
         $query_conversations = Conversation::getQueryByFolder($folder, $user->id);
+        if (
+            !empty($_GET['sort_by']) && !empty($_GET['order']) &&
+            in_array($_GET['sort_by'], ['subject', 'number', 'created_at']) &&
+            in_array($_GET['order'], ['asc', 'desc'])
+        )
+        {
+            $sort_by = $_GET['sort_by'];
+            $order = $_GET['order'];
+            $query_conversations = $query_conversations->orderBy($_GET['sort_by'], $_GET['order']);
+        }
+        else {
+            $sort_by = 'created_at';
+            $order = 'asc';
+        }
+ 
         $conversations = $folder->queryAddOrderBy($query_conversations)->paginate(Conversation::DEFAULT_LIST_SIZE);
 
         return view('mailboxes/view', [
@@ -456,6 +471,8 @@ class MailboxesController extends Controller
             'folders'       => $folders,
             'folder'        => $folder,
             'conversations' => $conversations,
+            'sort_by'       => $sort_by,
+            'order'         => $order
         ]);
     }
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2377,7 +2377,9 @@ function loadConversations(page, table, no_loader)
 			folder_id: getGlobalAttr('folder_id'),
 			filter: filter,
 			params: params,
-			page: page
+			page: page,
+			sortBy: getGlobalAttr('sort_by'),
+			order: getGlobalAttr('order')
 		},
 		laroute.route('conversations.ajax'),
 		function(response) {

--- a/resources/views/conversations/conversations_table.blade.php
+++ b/resources/views/conversations/conversations_table.blade.php
@@ -54,7 +54,13 @@
             @endif
             <th class="conv-attachment">&nbsp;</th>
             <th class="conv-subject" colspan="2">
-                <span>{{ __("Conversation") }}</span>
+                 <span>
+                        <a style="cursor: pointer" href="?sort_by=subject&order={{ $order == 'desc' ? 'asc' : 'desc' }}">
+                            {{ __("Conversation") }} 
+                             @if ($sort_by == 'subject' && $order =='desc')↑@endif
+                             @if ($sort_by == 'subject' && $order =='asc')↓@endif
+                        </a>
+                    </span>
             </th>
             @if ($show_assigned)
                 <th class="conv-owner">
@@ -71,11 +77,19 @@
             @endif
             @action('conversations_table.th_before_conv_number')
             <th class="conv-number">
-                <span>{{ __("Number") }}</span>
+                 <span>
+                        <a style="cursor: pointer" href="?sort_by=number&order={{ $order == 'desc' ? 'asc' : 'desc' }}">
+                            {{ __("Number") }} 
+                             @if ($sort_by == 'number' && $order =='desc')↑@endif
+                             @if ($sort_by == 'number' && $order =='asc')↓@endif
+                        </a>
+                    </span>
             </th>
             <th class="conv-date">
                 <span>
-                    @if ($folder->type == App\Folder::TYPE_CLOSED){{ __("Closed") }}@elseif ($folder->type == App\Folder::TYPE_DRAFTS){{ __("Last Updated") }}@elseif ($folder->type == App\Folder::TYPE_DELETED){{ __("Deleted") }}@else{{ \Eventy::filter('conversations_table.column_title_date', __("Waiting Since"), $folder) }}@endif<i class="conv-sort">↓</i>
+                    <a href="?sort_by=&created_at={{ $order == 'desc' ? 'asc' : 'desc' }}" style="cursor: pointer; display: inline">
+                        @if ($folder->type == App\Folder::TYPE_CLOSED){{ __("Closed") }}@elseif ($folder->type == App\Folder::TYPE_DRAFTS){{ __("Last Updated") }}@elseif ($folder->type == App\Folder::TYPE_DELETED){{ __("Deleted") }}@else{{ \Eventy::filter('conversations_table.column_title_date', __("Waiting Since"), $folder) }}@endif @if ($sort_by == 'created_at' && $order =='desc')↑@elseif ($sort_by == 'created_at' && $order =='asc')↓@elseif ($sort_by == '' && $order =='')↓@endif
+                    </a>
                 </span>
             </th>
           </tr>

--- a/resources/views/mailboxes/view.blade.php
+++ b/resources/views/mailboxes/view.blade.php
@@ -2,6 +2,8 @@
 
 @section('body_attrs')@parent data-mailbox_id="{{ $mailbox->id }}"@endsection
 @section('body_attrs')@parent data-folder_id="{{ $folder->id }}"@endsection
+@section('body_attrs')@parent data-sort_by="{{ $sort_by }}"@endsection
+@section('body_attrs')@parent data-order="{{ $order }}"@endsection
 
 @if ($folder->active_count)
     @section('title', '('.(int)$folder->getCount().') '.$folder->getTypeName().' - '.$mailbox->name)


### PR DESCRIPTION
The sorting can be done by clicking on the column names while showing correct sorting arrow next to the name when necessary. 

By default it it's using the created_at ascending order sorting.