### PR TITLE
Add autocomplete Tags to Auth Views

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -20,7 +20,7 @@
                             <label for="email" class="col-md-4 control-label">{{ __('Email Address') }}</label>
 
                             <div class="col-md-6">
-                                <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}" required autofocus>
+                                <input id="email" type="email" class="form-control" name="email" autocomplete="email" value="{{ old('email') }}" required autofocus>
 
                                 @if ($errors->has('email'))
                                     <span class="help-block">
@@ -34,7 +34,7 @@
                             <label for="password" class="col-md-4 control-label">{{ __('Password') }}</label>
 
                             <div class="col-md-6">
-                                <input id="password" type="password" class="form-control" name="password" required>
+                                <input id="password" type="password" class="form-control" name="password" autocomplete="current-password" required>
 
                                 @if ($errors->has('password'))
                                     <span class="help-block">

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -24,7 +24,7 @@
                             <label for="email" class="col-md-4 control-label">{{ __('Email Address') }}</label>
 
                             <div class="col-md-6">
-                                <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}" required>
+                                <input id="email" type="email" class="form-control" name="email" autocomplete="email" value="{{ old('email') }}" required>
 
                                 @if ($errors->has('email'))
                                     <span class="help-block">

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -20,7 +20,7 @@
                             <label for="email" class="col-md-4 control-label">{{ __('Email Address') }}</label>
 
                             <div class="col-md-6">
-                                <input id="email" type="email" class="form-control" name="email" value="{{ $email or old('email') }}" required autofocus>
+                                <input id="email" type="email" class="form-control" name="email" autocomplete="email" value="{{ $email or old('email') }}" required autofocus>
 
                                 @if ($errors->has('email'))
                                     <span class="help-block">
@@ -34,7 +34,7 @@
                             <label for="password" class="col-md-4 control-label">{{ __('Password') }}</label>
 
                             <div class="col-md-6">
-                                <input id="password" type="password" class="form-control" name="password" required>
+                                <input id="password" type="password" class="form-control" name="password" autocomplete="new-password" required>
 
                                 @if ($errors->has('password'))
                                     <span class="help-block">
@@ -47,7 +47,7 @@
                         <div class="form-group{{ $errors->has('password_confirmation') ? ' has-error' : '' }}">
                             <label for="password-confirm" class="col-md-4 control-label">{{ __('Confirm Password') }}</label>
                             <div class="col-md-6">
-                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required>
+                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" autocomplete="new-password" required>
 
                                 @if ($errors->has('password_confirmation'))
                                     <span class="help-block">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -18,7 +18,7 @@
                             <label for="first_name" class="col-md-4 control-label">{{ __('First name') }}</label>
 
                             <div class="col-md-6">
-                                <input id="first_name" type="text" class="form-control" name="first_name" value="{{ old('first_name') }}" required autofocus>
+                                <input id="first_name" type="text" class="form-control" name="first_name" autocomplete="given-name" value="{{ old('first_name') }}" required autofocus>
 
                                 @if ($errors->has('first_name'))
                                     <span class="help-block">
@@ -32,7 +32,7 @@
                             <label for="last_name" class="col-md-4 control-label">{{ __('Last name') }}</label>
 
                             <div class="col-md-6">
-                                <input id="last_name" type="text" class="form-control" name="last_name" value="{{ old('last_name') }}" required autofocus>
+                                <input id="last_name" type="text" class="form-control" name="last_name" autocomplete="family-name" value="{{ old('last_name') }}" required autofocus>
 
                                 @if ($errors->has('last_name'))
                                     <span class="help-block">
@@ -46,7 +46,7 @@
                             <label for="email" class="col-md-4 control-label">{{ __('E-mail address') }}</label>
 
                             <div class="col-md-6">
-                                <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}" required>
+                                <input id="email" type="email" class="form-control" name="email" autocomplete="email" value="{{ old('email') }}" required>
 
                                 @if ($errors->has('email'))
                                     <span class="help-block">
@@ -60,7 +60,7 @@
                             <label for="password" class="col-md-4 control-label">{{ __('Password') }}</label>
 
                             <div class="col-md-6">
-                                <input id="password" type="password" class="form-control" name="password" required>
+                                <input id="password" type="password" class="form-control" name="password" autocomplete="new-password" required>
 
                                 @if ($errors->has('password'))
                                     <span class="help-block">
@@ -74,7 +74,7 @@
                             <label for="password-confirm" class="col-md-4 control-label">{{ __('Confirm password') }}</label>
 
                             <div class="col-md-6">
-                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required>
+                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" autocomplete="new-password" required>
                             </div>
                         </div>
 


### PR DESCRIPTION
This Pull Request adds "autocomplete"-tags to all auth views of freescout to optimize its behavior in conjunction with a password manager.

It would be great if this could also be added to the 2FA/OTP Module
(in Resources/views/auth.blade.php:34 add autocomplete="one-time-code"

For reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete