### PR TITLE
add check for null passwords

### DIFF
--- a/app/Misc/Helper.php
+++ b/app/Misc/Helper.php
@@ -1261,7 +1261,8 @@ class Helper
      */
     public static function safePassword($password)
     {
-        return str_repeat("*", mb_strlen($password));
+        $len = ($password == null) ? 0 : mb_strlen($password);
+        return str_repeat("*", $len);
     }
 
     /**


### PR DESCRIPTION
Add code to handle null passwords in the safePassword function.

This was causing errors when trying to access the '/app-settings/emails' page for the first time.