### PR TITLE
Remove PHP version check, fixes #1819

### DIFF
--- a/tools/update.sh
+++ b/tools/update.sh
@@ -7,15 +7,6 @@
 DATE_TIME=`date +%Y-%m-%d_%H:%M:%S`
 echo -e "Starting upgrading: \e[32m${DATE_TIME}\e[0m";
 
-# Check PHP version
-php_v=`php -v | grep 'PHP 7' | wc -l`
-if [ $php_v != 1 ]; then
-	echo -e "\e[32mChecking PHP version...\e[0m";
-	php -v
-	echo -e "\e[31mInvalid PHP version (PHP 7.x is required)\e[0m";
-	exit;
-fi
-
 echo -e "\e[33mMake sure to create a backup of the application before you continue.\e[0m";
 
 # Determine project root


### PR DESCRIPTION
I believe FreeScout supports PHP 8.0.

This remove check from tools update.