### PR TITLE
add empty string check

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -322,7 +322,7 @@ class User extends Authenticatable
             //$mailboxes = $this->mailboxesCanViewWithSettings(true);
             $mailboxes = $this->mailboxesSettings();
             foreach ($mailboxes as $mailbox) {
-                if (!empty(json_decode($mailbox->access))) {
+                if (!empty($mailbox->access) && !empty(json_decode($mailbox->access))) {
                     return true;
                 }
             };


### PR DESCRIPTION
Added a check for empty strings passed to json_decode. This was throwing an error "json_decode(): Passing null to parameter #1 ($json) of type string is deprecated" when logged in as a standard user on PHP 8.1.