### PR TITLE
fixed undefined variable error

### DIFF
--- a/app/Http/Controllers/MailboxesController.php
+++ b/app/Http/Controllers/MailboxesController.php
@@ -770,7 +770,7 @@ class MailboxesController extends Controller
                     $mailbox_user = $user->mailboxesWithSettings()->where('mailbox_id', $mailbox->id)->first();
                     if (!$mailbox_user) {
                         // User may not be connected to the mailbox yet
-                        $user->mailboxes()->attach($id);
+                        $user->mailboxes()->attach($mailbox->id);
                         $mailbox_user = $user->mailboxesWithSettings()->where('mailbox_id', $mailbox->id)->first();
                     }
                     $mailbox_user->settings->mute = (bool)$request->mute;


### PR DESCRIPTION
Fixed undefined variable. This was throwing an error when trying to mute a mailbox.