### PR TITLE
Add header to enable easier mail filtering

### DIFF
--- a/app/Jobs/SendNotificationToUsers.php
+++ b/app/Jobs/SendNotificationToUsers.php
@@ -127,6 +127,7 @@ class SendNotificationToUsers implements ShouldQueue
             app()->setLocale($user->getLocale());
 
             $headers['X-FreeScout-Mail-Type'] = 'user.notification';
+            $headers['X-FreeScout-Mailbox-Name'] = $mailbox->name;
 
             $exception = null;
 


### PR DESCRIPTION
By adding a header that references the mailbox name, it is easier for support agents to set their desired filter rules. For example, an individual support agent may want notifications from some mailboxes, but not others. He turns on notifications on his account, but then has to use email filters to delete the ones he did not want.

Keep in mind that pull requests should be sent to the `master` branch! See https://github.com/freescout-helpdesk/freescout/wiki/Development-Guide#github-workflow

Now you can delete this text and type the description of your pull request...