### PR TITLE
Add header indicating mailbox name

### DIFF
--- a/app/Jobs/SendNotificationToUsers.php
+++ b/app/Jobs/SendNotificationToUsers.php
@@ -127,6 +127,7 @@ class SendNotificationToUsers implements ShouldQueue
             app()->setLocale($user->getLocale());
 
             $headers['X-FreeScout-Mail-Type'] = 'user.notification';
+            $headers['X-FreeScout-Mailbox-Name'] = $mailbox->name;
 
             $exception = null;
 


### PR DESCRIPTION
By adding a header that references the mailbox name, it is easier for support agents to set their desired filter rules. 

For example, an individual support agent may want notifications from some mailboxes, but not others. He turns on notifications on his account, but then has to use email filters to delete the ones he did not want. Or, he wishes to redirect notifications for different mailboxes to different final destinations.
