### PR TITLE
Add filters to be able to filter SMTP settings when sending a mail

### DIFF
--- a/app/Jobs/SendAutoReply.php
+++ b/app/Jobs/SendAutoReply.php
@@ -44,7 +44,7 @@ class SendAutoReply implements ShouldQueue
     public function handle()
     {
         // Configure mail driver according to Mailbox settings
-        \App\Misc\Mail::setMailDriver($this->mailbox);
+        \App\Misc\Mail::setMailDriver($this->mailbox, null, $this->conversation);
 
         // Auto reply appears as reply in customer's mailbox
         $headers['In-Reply-To'] = '<'.$this->thread->message_id.'>';

--- a/app/Jobs/SendEmailReplyError.php
+++ b/app/Jobs/SendEmailReplyError.php
@@ -44,7 +44,7 @@ class SendEmailReplyError implements ShouldQueue
     public function handle()
     {
         // Configure mail driver according to Mailbox settings
-        \App\Misc\Mail::setMailDriver($this->mailbox);
+        \App\Misc\Mail::setMailDriver($this->mailbox, null, $this->conversation);
 
         $exception = null;
 

--- a/app/Jobs/SendNotificationToUsers.php
+++ b/app/Jobs/SendNotificationToUsers.php
@@ -47,7 +47,7 @@ class SendNotificationToUsers implements ShouldQueue
         $mailbox = $this->conversation->mailbox;
 
         // Configure mail driver according to Mailbox settings
-        \App\Misc\Mail::setMailDriver($mailbox);
+        \App\Misc\Mail::setMailDriver($mailbox, null, $this->conversation);
 
         // Threads has to be sorted here, if sorted before, they come here in wrong order
         $this->threads = $this->threads->sortByDesc(function ($item, $key) {

--- a/app/Jobs/SendReplyToCustomer.php
+++ b/app/Jobs/SendReplyToCustomer.php
@@ -162,7 +162,7 @@ class SendReplyToCustomer implements ShouldQueue
         }
 
         // Configure mail driver according to Mailbox settings
-        \App\Misc\Mail::setMailDriver($mailbox, $this->last_thread->created_by_user);
+        \App\Misc\Mail::setMailDriver($mailbox, $this->last_thread->created_by_user, $this->conversation);
 
         // Get penultimate email Message-Id if reply
         if (!$new && !empty($last_customer_thread) && $last_customer_thread->message_id) {
@@ -273,7 +273,7 @@ class SendReplyToCustomer implements ShouldQueue
                 $client = \MailHelper::getMailboxClient($mailbox);
                 $client->connect();
 
-                $envelope['from'] = $mailbox->getMailFrom()['address'];
+                $envelope['from'] = $mailbox->getMailFrom(null, $this->conversation)['address'];
                 $envelope['to'] = $this->customer_email;
                 $envelope['subject'] = 'Re: ' . $this->conversation->subject;
 

--- a/app/Mailbox.php
+++ b/app/Mailbox.php
@@ -533,10 +533,11 @@ class Mailbox extends Model
      * Get From array for the Mail function.
      *
      * @param App\User $from_user
+     * @param App\Conversation $conversation
      *
      * @return array
      */
-    public function getMailFrom($from_user = null)
+    public function getMailFrom($from_user = null, $conversation = null)
     {
         // Mailbox name by default
         $name = $this->name;
@@ -547,7 +548,7 @@ class Mailbox extends Model
             $name = $from_user->getFullName();
         }
 
-        return ['address' => $this->email, 'name' => $name];
+        return [ 'address' => \Eventy::filter( 'mailbox.get_mail_from_address', $this->email, $from_user, $conversation ), 'name' => $name ];
     }
 
     /**

--- a/app/Misc/Mail.php
+++ b/app/Misc/Mail.php
@@ -83,13 +83,15 @@ class Mail
      * Configure mail sending parameters.
      *
      * @param App\Mailbox $mailbox
+     * @param App\User $user_from
+     * @param App\Conversation $conversation
      */
-    public static function setMailDriver($mailbox = null, $user_from = null)
+    public static function setMailDriver($mailbox = null, $user_from = null, $conversation = null)
     {
         if ($mailbox) {
             // Configure mail driver according to Mailbox settings
             \Config::set('mail.driver', $mailbox->getMailDriverName());
-            \Config::set('mail.from', $mailbox->getMailFrom($user_from));
+            \Config::set('mail.from', $mailbox->getMailFrom($user_from, $conversation));
 
             // SMTP
             if ($mailbox->out_method == Mailbox::OUT_METHOD_SMTP) {


### PR DESCRIPTION
A customer would like an (outgoing) alias module. For that to work, the outgoing address should be filtered.
This PR adds the necessary filters for that.

I tried to keep it as clean as possible.