### PR TITLE
Add filter allowing customisation of outgoing headers

### DIFF
--- a/app/Jobs/SendNotificationToUsers.php
+++ b/app/Jobs/SendNotificationToUsers.php
@@ -127,6 +127,7 @@ class SendNotificationToUsers implements ShouldQueue
             app()->setLocale($user->getLocale());
 
             $headers['X-FreeScout-Mail-Type'] = 'user.notification';
+            $headers = \Eventy::filter('jobs.send_reply_to_customer.mail_headers', $headers, $user, $mailbox, $this->conversation, $this->threads, $from);
 
             $exception = null;
 


### PR DESCRIPTION
I wish to add a header to outgoing mail (see: https://github.com/freescout-helpdesk/freescout/pull/1866). I was told to do it as an external module.

This PR adds the necessary filter to allow that.