### PR TITLE
Implements required actions to allow custom mailbox icons/logos

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -86,7 +86,7 @@
                                     </a>
                                     <ul class="dropdown-menu dm-scrollable">
                                         @foreach ($mailboxes as $mailbox_item)
-                                            <li @if ($mailbox_item->id == app('request')->id)class="active"@endif><a href="{{ \Eventy::filter('mailbox.url', route('mailboxes.view', ['id' => $mailbox_item->id]), $mailbox_item) }}">{{ $mailbox_item->name }}</a></li>
+                                            <li @if ($mailbox_item->id == app('request')->id)class="active"@endif><a href="{{ \Eventy::filter('mailbox.url', route('mailboxes.view', ['id' => $mailbox_item->id]), $mailbox_item) }}">@action('mailbox.before_name', $mailbox_item){{ $mailbox_item->name }}</a></li>
                                         @endforeach
                                     </ul>
                                 </li>

--- a/resources/views/mailboxes/sidebar_menu_view.blade.php
+++ b/resources/views/mailboxes/sidebar_menu_view.blade.php
@@ -1,5 +1,6 @@
 <div class="dropdown sidebar-title sidebar-title-extra">
     <span class="sidebar-title-extra-value active-count">{{ $folder->getTypeName() }} ({{ $folder->active_count }})</span>
+    @action('mailbox.before_name', $mailbox)
     <span class="sidebar-title-real mailbox-name">@include('mailboxes/partials/mute_icon', ['mailbox' => $mailbox]){{ $mailbox->name }}</span>
     <span class="sidebar-title-email">{{ $mailbox->email }}</span>
 </div>

--- a/resources/views/mailboxes/update.blade.php
+++ b/resources/views/mailboxes/update.blade.php
@@ -19,7 +19,7 @@
     <div class="row-container form-container">
         <div class="row">
             <div class="col-xs-12">
-                <form class="form-horizontal margin-top" method="POST" action="">
+                <form class="form-horizontal margin-top" method="POST" action="" enctype="multipart/form-data">
                     {{ csrf_field() }}
 
                     <div class="form-group{{ $errors->has('name') ? ' has-error' : '' }}">

--- a/resources/views/secure/dashboard.blade.php
+++ b/resources/views/secure/dashboard.blade.php
@@ -11,6 +11,7 @@
             @foreach ($mailboxes as $mailbox)
                 <div class="dash-card @if (!$mailbox->isActive()) dash-card-inactive @endif">
                     <div class="dash-card-content">
+                        @action('mailbox.before_name', $mailbox)
                         <h3 class="text-wrap-break "><a href="{{ $mailbox->url() }}" class="mailbox-name">@include('mailboxes/partials/mute_icon', ['mailbox' => $mailbox]){{ $mailbox->name }}</a></h3>
                         <div class="dash-card-link text-truncate">
                             <a href="{{ $mailbox->url() }}" class="text-truncate help-link">{{ $mailbox->email }}</a>


### PR DESCRIPTION
These changes are required for a module to display a custom logo for each mailbox, as [requested before](https://github.com/freescout-helpdesk/freescout/issues/1864).

1. Add the action `mailbox.before_name` to: (1) dashboard cards, (2) sidebar menu, (3) mailbox dropdown menu.
2. Allow file uploads (by using `enctype="multipart/form-data"`) for mailbox settings form.

Thanks