### PR TITLE
Small optimizations to better style dashboard cards and sidebar folders

### DIFF
--- a/resources/views/mailboxes/partials/folders.blade.php
+++ b/resources/views/mailboxes/partials/folders.blade.php
@@ -5,15 +5,16 @@
             ($folder_item->type != App\Folder::TYPE_DRAFTS || ($folder_item->type == App\Folder::TYPE_DRAFTS && $folder_item->total_count))
         )
     )
-        <li class="@if ($folder_item->id == $folder->id) active @endif" data-folder_id="{{ $folder_item->id }}">
+        @php
+            if ($folder_item->type == App\Folder::TYPE_SPAM) {
+                $active_count = $folder_item->total_count;
+            } else {
+                $active_count = $folder_item->getCount($folders);
+            }
+        @endphp
+        <li class="{{ $folder_item->getTypeIcon() }}@if ($folder_item->id == $folder->id) active @endif" data-folder_id="{{ $folder_item->id }}" data-active-count="{{ $folder_item->active_count }}">
             <a href="{{ $folder_item->url($mailbox->id) }}" @if (!$folder_item->active_count) class="no-active" @endif><i class="glyphicon glyphicon-{{ $folder_item->getTypeIcon() }}"></i> <span class="folder-name">{{ $folder_item->getTypeName() }}</span>
-                @php
-                    if ($folder_item->type == App\Folder::TYPE_SPAM) {
-                        $active_count = $folder_item->total_count;
-                    } else {
-                        $active_count = $folder_item->getCount($folders);
-                    }
-                @endphp
+                
                 @if ($active_count)
                     @if ($folder_item->type == App\Folder::TYPE_UNASSIGNED || $folder_item->type == App\Folder::TYPE_MINE)
                         <strong class="active-count pull-right" data-toggle="tooltip" title="{{ __("Active Conversations") }}">{{ $active_count }}</strong>

--- a/resources/views/secure/dashboard.blade.php
+++ b/resources/views/secure/dashboard.blade.php
@@ -9,7 +9,7 @@
     @if (count($mailboxes))
         <div class="dash-cards margin-top">
             @foreach ($mailboxes as $mailbox)
-                <div class="dash-card @if (!$mailbox->isActive()) dash-card-inactive @endif">
+                <div class="dash-card @if (!$mailbox->isActive()) dash-card-inactive @endif" data-mailbox-id="{{ $mailbox->id }}">
                     <div class="dash-card-content">
                         @action('mailbox.before_name', $mailbox)
                         <h3 class="text-wrap-break "><a href="{{ $mailbox->url() }}" class="mailbox-name">@include('mailboxes/partials/mute_icon', ['mailbox' => $mailbox]){{ $mailbox->name }}</a></h3>


### PR DESCRIPTION
This pull request is:
### 1. Adding the mailbox-id as a data attribute to the dashboard card
Helpful when cards need to have different stylings or the global mailbox needs to be styled differently than normal mailboxes.

Example:
![grafik](https://user-images.githubusercontent.com/2457916/176824939-02b69a30-5408-47d5-b6c4-ccd6f3bdd738.png)

### 2. Adding folder icons as class names to the sidebar
Allowing the icon name as a class selector is required to change the order of the folders in the sidebar.
It is also useful when adding css-only diviers.

### 3. Adding `$active_count` as a data attribute to sidebar folders
Can be used to hide empty folders from the sidebar. Especially useful when used together with the icon class name.

Example:
![grafik](https://user-images.githubusercontent.com/2457916/176825064-1f8a1644-941b-4403-b5ff-9c2f93f80ed3.png)

These changes are not vital, but create more flexibility when styling FreeScout using the official [Customization module](https://freescout.net/module/customization/).

Thanks!