### PR TITLE
Default folder INBOX

### DIFF
--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -162,6 +162,12 @@ class FetchEmails extends Command
             $this->line('['.date('Y-m-d H:i:s').'] Fetching: '.($unseen ? 'UNREAD' : 'ALL'));
         }
 
+        if(0 == count($folders)) {
+            // Set default box INBOX (usefull for pop3)
+            $folder = $client->getFolder('INBOX');
+            $folders[] = $folder;
+        }
+
         foreach ($folders as $folder) {
             $this->line('['.date('Y-m-d H:i:s').'] Folder: '.$folder->name);
 


### PR DESCRIPTION
Hello,

This is a fix to a pop3 mail account. As the fetching is OK (logs), but no ticket created.
I found that no folder was processed if not in IMAP protocols.

Fix #2092 