### PR TITLE
Changes for #2141 - fixes for UI issues for conversation display in kanban

### DIFF
--- a/app/Http/Controllers/ConversationsController.php
+++ b/app/Http/Controllers/ConversationsController.php
@@ -390,7 +390,7 @@ class ConversationsController extends Controller
                     // Determine redirect
                     // Must be done before updating current conversation's status or assignee.
                     $redirect_same_page = false;
-                    if ($new_user_id == $user->id) {
+                    if ($new_user_id == $user->id || $request->x_embed==1) {
                         // If user assigned conversation to himself, stay on the current page
                         $response['redirect_url'] = $conversation->url();
                         $redirect_same_page = true;
@@ -449,7 +449,7 @@ class ConversationsController extends Controller
                     // Determine redirect
                     // Must be done before updating current conversation's status or assignee.
                     $redirect_same_page = false;
-                    if ($request->status == 'not_spam') {
+                    if ($request->status == 'not_spam' || $request->x_embed==1) {
                         // Stay on the current page
                         $response['redirect_url'] = $conversation->url();
                         $redirect_same_page = true;
@@ -2168,6 +2168,7 @@ class ConversationsController extends Controller
      */
     public function getRedirectUrl($request, $conversation, $user)
     {
+
         // If conversation is a draft, we always display Drafts folder
         if ($conversation->state == Conversation::STATE_DRAFT) {
             return route('mailboxes.view.folder', ['id' => $conversation->mailbox_id, 'folder_id' => $conversation->folder_id]);

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -848,21 +848,40 @@ function fsAjax(data, url, success_callback, no_loader, error_callback, custom_o
 	}
 
 	// If this is conversation ajax request, add folder_id to the URL
-	if (url.indexOf('/conversation/') != -1) {
-		var folder_id = getQueryParam('folder_id');
-		if (folder_id) {
-			url += '?folder_id='+folder_id;
-		}
-	}
+    if (url.indexOf('/conversation/') != -1) {
+        var folder_id = getQueryParam('folder_id');
+        if (folder_id) {
+        	url = addQueryParam('folder_id',folder_id,url);
+        }
+    }
 
-	var options = {
-		url: url,
-		method: 'post',
-		dataType: 'json',
-		data: data,
-		success: success_callback,
-		error: error_callback
-    };
+    var preserve_xembed = false;
+    if (window.location.href.indexOf('x_embed=1') != -1) {
+    	url = addQueryParam('x_embed',1,url);
+        preserve_xembed = true;
+    	}
+
+        var override_success_callback = function(response) {
+
+            if (typeof(response.redirect_url) != "undefined") {
+
+                if (preserve_xembed && response.redirect_url.indexOf('x_embed=1') == -1) {
+                	response.redirect_url = addQueryParam('x_embed',1,response.redirect_url);
+                }
+
+            }
+
+            return success_callback(response);
+        };
+
+        var options = {
+            url: url,
+            method: 'post',
+            dataType: 'json',
+            data: data,
+            success: override_success_callback,
+            error: error_callback
+        };
 
     if (typeof(custom_options) == "object") {
     	options = {...options, ...custom_options};
@@ -2094,6 +2113,17 @@ function getQueryParam(name, qs) {
     } else {
     	return '';
     }
+}
+
+function addQueryParam(name,value,url)
+{
+	var search = url.substring(url.indexOf('?')+1);
+	if (search != url) {
+		return url + '&'+encodeURIComponent(name)+'='+encodeURIComponent(value);
+	}
+	else {
+		return url + '?'+encodeURIComponent(name)+'='+encodeURIComponent(value);
+	}
 }
 
 // Show bootstrap modal

--- a/resources/views/conversations/partials/thread.blade.php
+++ b/resources/views/conversations/partials/thread.blade.php
@@ -16,8 +16,8 @@
             @if (Auth::user()->isAdmin())
                 <ul class="dropdown-menu dropdown-menu-right" role="menu">
                     @action('thread.menu', $thread)
-                    <li><a href="{{ route('conversations.ajax_html', ['action' =>
-                        'send_log']) }}?thread_id={{ $thread->id }}" title="{{ __("View outgoing emails") }}" data-trigger="modal" data-modal-title="{{ __("Outgoing Emails") }}" data-modal-size="lg">{{ __("Outgoing Emails") }}</a></li>
+                    <li><a href="{{ route('conversations.ajax_html', array_merge(['action' =>
+                        'send_log'], \Request::all(), ['thread_id' => $thread->id])) }}" title="{{ __("View outgoing emails") }}" data-trigger="modal" data-modal-title="{{ __("Outgoing Emails") }}" data-modal-size="lg">{{ __("Outgoing Emails") }}</a></li>
                     @action('thread.menu.append', $thread)
                 </ul>
             @endif
@@ -218,10 +218,10 @@
                     @endif
                 @endif
                 @if ($thread->isSendStatusError())
-                        <div class="alert alert-danger alert-light">
+                        <div class="alert alert-danger alert-light"> 
                             <div>
-                                <strong>{{ __('Message not sent to customer') }}</strong> (<a href="{{ route('conversations.ajax_html', ['action' =>
-                        'send_log']) }}?thread_id={{ $thread->id }}" data-trigger="modal" data-modal-title="{{ __("Outgoing Emails") }}" data-modal-size="lg">{{ __('View log') }}</a>)
+                                <strong>{{ __('Message not sent to customer') }}</strong> (<a href="{{ route('conversations.ajax_html', array_merge(['action' =>
+                        'send_log'], \Request::all(), ['thread_id' => $thread->id]) ) }}" data-trigger="modal" data-modal-title="{{ __("Outgoing Emails") }}" data-modal-size="lg">{{ __('View log') }}</a>)
                             </div>
 
                             @if (!empty($send_status_data['bounced_by_thread']) && !empty($send_status_data['bounced_by_conversation']))
@@ -286,17 +286,17 @@
             <ul class="dropdown-menu dropdown-menu-right" role="menu">
                 @if (Auth::user()->can('edit', $thread))
                     <li><a href="#" title="" class="thread-edit-trigger" role="button">{{ __("Edit") }}</a></li>
-                @endif
+                @endif 
                 {{--<li><a href="javascript:alert('todo: implement hiding threads');void(0);" title="" class="thread-hide-trigger">{{ __("Hide") }} (todo)</a></li>--}}
                 <li><a href="{{ route('conversations.create', ['mailbox_id' => $mailbox->id]) }}?from_thread_id={{ $thread->id }}" title="{{ __("Start a conversation from this thread") }}" class="new-conv" role="button">{{ __("New Conversation") }}</a></li>
                 @action('thread.menu', $thread)
                 @if (Auth::user()->isAdmin())
-                    <li><a href="{{ route('conversations.ajax_html', ['action' =>
-                        'send_log']) }}?thread_id={{ $thread->id }}" title="{{ __("View outgoing emails") }}" data-trigger="modal" data-modal-title="{{ __("Outgoing Emails") }}" data-modal-size="lg" role="button">{{ __("Outgoing Emails") }}</a></li>
+                    <li><a href="{{ route('conversations.ajax_html', array_merge(['action' =>
+                        'send_log'], \Request::all(), ['thread_id' => $thread->id])) }}" title="{{ __("View outgoing emails") }}" data-trigger="modal" data-modal-title="{{ __("Outgoing Emails") }}" data-modal-size="lg" role="button">{{ __("Outgoing Emails") }}</a></li>
                 @endif
                 @if ($thread->isReply())
-                    <li><a href="{{ route('conversations.ajax_html', ['action' =>
-                        'show_original']) }}?thread_id={{ $thread->id }}" title="{{ __("Show original message") }}" data-trigger="modal" data-modal-title="{{ __("Original Message") }}" data-modal-fit="true" data-modal-size="lg" role="button">{{ __("Show Original") }}</a></li>
+                    <li><a href="{{ route('conversations.ajax_html', array_merge(['action' =>
+                        'show_original'], \Request::all(), ['thread_id' => $thread->id])) }}" title="{{ __("Show original message") }}" data-trigger="modal" data-modal-title="{{ __("Original Message") }}" data-modal-fit="true" data-modal-size="lg" role="button">{{ __("Show Original") }}</a></li>
                 @endif
                 @if ($thread->isReply() || $thread->isNote())
                     <li><a href="{{ \Request::getRequestUri() }}&amp;print_thread_id={{ $thread->id }}&amp;print=1" target="_blank" role="button">{{ __("Print") }}</a></li>

--- a/resources/views/conversations/view.blade.php
+++ b/resources/views/conversations/view.blade.php
@@ -49,12 +49,12 @@
                                 <li><a href="#" class="conv-forward" role="button"><i class="glyphicon glyphicon-arrow-right"></i> {{ __("Forward") }}</a></li>
                             @endif
                             @if (!$conversation->isChat())
-                                <li><a href="{{ route('conversations.ajax_html', ['action' =>
-                                                'merge_conv']) }}?conversation_id={{ $conversation->id }}" data-trigger="modal" data-modal-title="{{ __("Merge Conversations") }}" data-modal-no-footer="true" data-modal-on-show="initMergeConv" role="button"><i class="glyphicon glyphicon-indent-left"></i> {{ __("Merge") }}</a></li>
+                                <li><a href="{{ route('conversations.ajax_html', array_merge(['action' =>
+                        'merge_conv'], \Request::all(), ['conversation_id' => $conversation->id]) ) }}" data-trigger="modal" data-modal-title="{{ __("Merge Conversations") }}" data-modal-no-footer="true" data-modal-on-show="initMergeConv" role="button"><i class="glyphicon glyphicon-indent-left"></i> {{ __("Merge") }}</a></li>
                             @endif
                             @if (Auth::user()->can('move', App\Conversation::class))
-                                <li><a href="{{ route('conversations.ajax_html', ['action' =>
-                                            'move_conv']) }}?conversation_id={{ $conversation->id }}" data-trigger="modal" data-modal-title="{{ __("Move Conversation") }}" data-modal-no-footer="true" data-modal-on-show="initMoveConv" role="button"><i class="glyphicon glyphicon-log-out"></i> {{ __("Move") }}</a></li>
+                                <li><a href="{{ route('conversations.ajax_html', array_merge(['action' =>
+                        'move_conv'], \Request::all(), ['conversation_id' => $conversation->id]) ) }}" data-trigger="modal" data-modal-title="{{ __("Move Conversation") }}" data-modal-no-footer="true" data-modal-on-show="initMoveConv" role="button"><i class="glyphicon glyphicon-log-out"></i> {{ __("Move") }}</a></li>
                             @endif
                             @if ($conversation->state != App\Conversation::STATE_DELETED)
                                 <li class="hidden-lg hidden-md hidden-sm"><a href="#" class="conv-delete" role="button"><i class="glyphicon glyphicon-trash"></i> {{ __("Delete") }}</a></li>
@@ -262,8 +262,8 @@
                         <ul class="dropdown-menu dropdown-menu-right" role="menu">
                             <li role="presentation"><a href="{{ route('customers.update', ['id' => $customer->id]) }}" tabindex="-1" role="menuitem">{{ __("Edit Profile") }}</a></li>
                             @if (!$conversation->isChat())
-                                <li role="presentation"><a href="{{ route('conversations.ajax_html', ['action' =>
-                                            'change_customer']) }}?conversation_id={{ $conversation->id }}" data-trigger="modal" data-modal-title="{{ __("Change Customer") }}" data-modal-no-footer="true" data-modal-on-show="changeCustomerInit" tabindex="-1" role="menuitem">{{ __("Change Customer") }}</a></li>
+                                <li role="presentation"><a href="{{ route('conversations.ajax_html', array_merge(['action' =>
+                        'change_customer'], \Request::all(), ['conversation_id' => $conversation->id]) ) }}" data-trigger="modal" data-modal-title="{{ __("Change Customer") }}" data-modal-no-footer="true" data-modal-on-show="changeCustomerInit" tabindex="-1" role="menuitem">{{ __("Change Customer") }}</a></li>
                             @endif
                             @if (count($prev_conversations))
                                 <li role="presentation" class="col3-hidden"><a data-toggle="collapse" href=".collapse-conv-prev" tabindex="-1" role="menuitem">{{ __("Previous Conversations") }}</a></li>


### PR DESCRIPTION
As discussed in #2141, changes to preserve the x_embed param while conversations are worked on in an iframe (e.g. with the kanban module):
- Fixes some routes in views to preserve existing query params (this fixes actions like view outgoing emails in conversation modal view)
- Checks for x_embed in current URL and appends to redirect URL - this preserves the modal display, which excludes the top nav menu, while working within the iframe.
- Changes to conversation controller to stay on same page if iframe and not redirect to conversation list (as conversation list is available in the kanban master window).