### PR TITLE
Allowing multiple summernote hints

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1507,6 +1507,7 @@ function convEditorInit()
 		followingToolbar: false,
 		toolbar: fsApplyFilter('conversation.editor_toolbar', fs_conv_editor_toolbar),
 		buttons: fs_conv_editor_buttons,
+        hint: [],
 		callbacks: {
 	 		onImageUpload: function(files) {
 	 			if (!files) {


### PR DESCRIPTION
The [Mentions Module](https://freescout.net/module/mentions/) is using the Summernote `hint` feature by assigning an object to `options.hint`:
```js
/Modules/Mentions/Public/js/module.js:8
options.hint = {...}
```
This results in other modules not being able to use their own hints without risking being overwritten by the Mentions Module.
Luckily summernote supports multiple hints by using an array instead of an object.

This pull request is initializing `options.hint` as an empty array - in order to populate it within modules.

Accepting this pull request requires the following changes to the Mentions Module's javascript:
```js
/Modules/Mentions/Public/js/module.js:8
options.hint.push({...})
```
