### PR TITLE
Make conversation history table wider in customer profile, Fix #61

### DIFF
--- a/resources/views/conversations/conversations_table.blade.php
+++ b/resources/views/conversations/conversations_table.blade.php
@@ -187,7 +187,7 @@
                         <strong>{{ $conversations->firstItem() }}</strong>-<strong>{{ $conversations->lastItem() }}</strong>
                     @endif
                 </td>
-                <td colspan="3" class="conv-nav">
+                <td colspan="1" class="conv-nav">
                     <div class="table-pager">
                         @if ($conversations)
                             {{ $conversations->links('conversations/conversations_pagination') }}


### PR DESCRIPTION
Before

<img width="1394" alt="Screen Shot 2022-09-12 at 12 05 24" src="https://user-images.githubusercontent.com/382183/189702788-3cb7a2de-67da-404a-8842-2da95f607c06.png">

After

<img width="1394" alt="Screen Shot 2022-09-12 at 12 05 26" src="https://user-images.githubusercontent.com/382183/189702810-2a702c6e-da1b-4e8e-b8cd-9e569114d274.png">

---

Requesting testing by others to confirm this does not mess up other uses of conversation view, specifically with paging.