### PR TITLE
Add possibility to clone a conversation.

### DIFF
--- a/resources/views/conversations/partials/thread.blade.php
+++ b/resources/views/conversations/partials/thread.blade.php
@@ -218,7 +218,7 @@
                     @endif
                 @endif
                 @if ($thread->isSendStatusError())
-                        <div class="alert alert-danger alert-light"> 
+                        <div class="alert alert-danger alert-light">
                             <div>
                                 <strong>{{ __('Message not sent to customer') }}</strong> (<a href="{{ route('conversations.ajax_html', array_merge(['action' =>
                         'send_log'], \Request::all(), ['thread_id' => $thread->id]) ) }}" data-trigger="modal" data-modal-title="{{ __("Outgoing Emails") }}" data-modal-size="lg">{{ __('View log') }}</a>)
@@ -286,9 +286,10 @@
             <ul class="dropdown-menu dropdown-menu-right" role="menu">
                 @if (Auth::user()->can('edit', $thread))
                     <li><a href="#" title="" class="thread-edit-trigger" role="button">{{ __("Edit") }}</a></li>
-                @endif 
+                @endif
                 {{--<li><a href="javascript:alert('todo: implement hiding threads');void(0);" title="" class="thread-hide-trigger">{{ __("Hide") }} (todo)</a></li>--}}
                 <li><a href="{{ route('conversations.create', ['mailbox_id' => $mailbox->id]) }}?from_thread_id={{ $thread->id }}" title="{{ __("Start a conversation from this thread") }}" class="new-conv" role="button">{{ __("New Conversation") }}</a></li>
+                <li><a href="{{ route('conversations.cloneconversation', ['mailbox_id' => $mailbox->id]) }}?from_thread_id={{ $thread->id }}" title="{{ __("Clone a conversation from this thread") }}" class="new-conv" role="button">{{ __("Clone Conversation") }}</a></li>
                 @action('thread.menu', $thread)
                 @if (Auth::user()->isAdmin())
                     <li><a href="{{ route('conversations.ajax_html', array_merge(['action' =>

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,6 +65,7 @@ Route::get('/conversation/{id}', ['uses' => 'ConversationsController@view', 'lar
 Route::post('/conversation/ajax', ['uses' => 'ConversationsController@ajax', 'laroute' => true])->name('conversations.ajax');
 Route::post('/conversation/upload', ['uses' => 'ConversationsController@upload', 'laroute' => true])->name('conversations.upload');
 Route::get('/mailbox/{mailbox_id}/new-ticket', 'ConversationsController@create')->name('conversations.create');
+Route::get('/mailbox/{mailbox_id}/clone-ticket', 'ConversationsController@cloneconversation')->name('conversations.cloneconversation');
 //Route::get('/conversation/draft/{id}', 'ConversationsController@draft')->name('conversations.draft');
 Route::get('/conversation/ajax-html/{action}', ['uses' => 'ConversationsController@ajaxHtml', 'laroute' => true])->name('conversations.ajax_html');
 Route::get('/search', 'ConversationsController@search')->name('conversations.search');


### PR DESCRIPTION
Hi there,

We sometimes see that customers are hijacking a conversation by switching to a different issue while replying to the previous issue. It ends up in freescout, ideally we want to disconnect that message from the conversation, so we keep this new issue separated from the old.

This feature adds a 'clone conversation' to the context menu of messages and makes a brand new conversation based on that message. Somewhat similar to 'new conversation'. The original conversations remains the same, because it most likely also references the issue in that thread, so we don't want to remove it there.

I hope I did everything right, my first pull request, so please do not scream at me.

Tom