### PR TITLE
Fix Logs date format display issue

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -488,6 +488,7 @@ class User extends Authenticatable
                         'H'     => 'h',
                         'G'     => 'g',
                         ':i'    => ':ia',
+                        ':i:s'  => ':i:sa',
                         ':ia:s' => ':i:sa',
                     ]);
                 } else {


### PR DESCRIPTION
logs.blade.php calls `User::dateFormat` with the format string `M j, H:i:s`

If 12hr time is selected, `/app-logs/user` and `/app-logs/out_emails` were displaying the date with the seconds appearing after am/pm. e.g. Feb 19, 03:49pm:09

The `User::dateFormat` function was translating `:i` => `:ia`.
The PHP function `subtr()` will try longer keys first so by adding the key/value pair `:i:s` => `:i:s:a` we can get the correct output.