### PR TITLE
Update folders counters in background

### DIFF
--- a/app/Jobs/UpdateFolderCounters.php
+++ b/app/Jobs/UpdateFolderCounters.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Conversation;
+use App\ConversationFolder;
+use App\Folder;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class UpdateFolderCounters implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * @var Folder
+     */
+    private $folder;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Folder $folder)
+    {
+        $this->folder = $folder;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        try {
+            if ( \Eventy::filter( 'folder.update_counters', false, $this->folder ) ) {
+                \Cache::forget( 'updating_folder_' . $this->folder->id );
+
+                return;
+            }
+            if ( $this->folder->type == Folder::TYPE_MINE && $this->folder->user_id ) {
+                $this->folder->active_count = Conversation::where( 'user_id', $this->folder->user_id )
+                                                          ->where( 'mailbox_id', $this->folder->mailbox_id )
+                                                          ->where( 'state', Conversation::STATE_PUBLISHED )
+                                                          ->where( 'status', Conversation::STATUS_ACTIVE )
+                                                          ->count();
+                $this->folder->total_count  = Conversation::where( 'user_id', $this->folder->user_id )
+                                                          ->where( 'mailbox_id', $this->folder->mailbox_id )
+                                                          ->where( 'state', Conversation::STATE_PUBLISHED )
+                                                          ->count();
+            } else if ( $this->folder->type == Folder::TYPE_STARRED ) {
+                $this->folder->active_count = count( Conversation::getUserStarredConversationIds( $this->folder->mailbox_id, $this->folder->user_id ) );
+                $this->folder->total_count  = $this->folder->active_count;
+            } else if ( $this->folder->type == Folder::TYPE_DELETED ) {
+                $this->folder->active_count = $this->folder->conversations()->where( 'state', Conversation::STATE_DELETED )
+                                                           ->count();
+                $this->folder->total_count  = $this->folder->active_count;
+            } else if ( $this->folder->isIndirect() ) {
+                // Conversation are connected to folder via conversation_folder table.
+                // Drafts.
+                $this->folder->active_count = ConversationFolder::where( 'conversation_folder.folder_id', $this->folder->id )
+                                                                ->join( 'conversations', 'conversations.id', '=', 'conversation_folder.conversation_id' )
+                    //->where('state', Conversation::STATE_PUBLISHED)
+                                                                ->count();
+                $this->folder->total_count  = $this->folder->active_count;
+            } else {
+                $this->folder->active_count = $this->folder->conversations()
+                                                           ->where( 'state', Conversation::STATE_PUBLISHED )
+                                                           ->where( 'status', Conversation::STATUS_ACTIVE )
+                                                           ->count();
+                $this->folder->total_count  = $this->folder->conversations()
+                                                           ->where( 'state', Conversation::STATE_PUBLISHED )
+                                                           ->count();
+            }
+            $this->folder->save();
+        } catch ( \Exception $e ) {
+            // Always clear the cache
+        }
+        \Cache::forget( 'updating_folder_' . $this->folder->id );
+    }
+}


### PR DESCRIPTION
When you have a lot of mailboxes, a lot of users and you use tags and the custom folders plugin excessively, every action becomes extremely slow (on serious dedicated hardware, sending a mail took 20s, deleting the same), because each action triggers a updateCounters for each folder. 

In this PR, the updateCounters function is moved to a job. When you have an extreme amount of folders, it will take a few seconds before the counters update, but everything else is way faster. When you have 1 mailbox with some folders, you won't notice a difference.

I also built a small part that checks if the job is already queued. If it is, it won't be added again. So removing 10 mails won't add all folders 10 times to the queue. Feel free to make this optional via the settings or something (you could use dispatchNow instead of dispatch when some setting is set for example)