### PR TITLE
Unfollow followed conversation when re/assigned

### DIFF
--- a/app/Conversation.php
+++ b/app/Conversation.php
@@ -645,6 +645,16 @@ class Conversation extends Model
         $this->user_id = $user_id;
         $this->updateFolder();
         $this->user_updated_at = $now;
+		
+        // If user was previously following the conversation then unfollow
+        if (!is_null($user_id)) {
+            $follower = Follower::where('conversation_id', $this->id)
+                ->where('user_id', $user_id)
+                ->first();
+            if ($follower) {
+                $follower->delete();
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
If a user is "following" a conversation and the conversation is then assigned to them they no longer need to follow it.
PR for issue #2994 