### PR TITLE
Fixed undefined variable bug in the FollowerObserver

### DIFF
--- a/app/Observers/FollowerObserver.php
+++ b/app/Observers/FollowerObserver.php
@@ -8,7 +8,7 @@ class FollowerObserver
 {
     public function created(Follower $follower)
     {
-        \Eventy::action('follower.created', $attachment);
+        \Eventy::action('follower.created', $follower);
     }
 
     public function deleted(Follower $follower)


### PR DESCRIPTION
This PR fixes the "Undefined variable: attachment" error in the FollowerObserver class.