### PR TITLE
Speed up eventy event firing

### DIFF
--- a/overrides/tormjens/eventy/src/Action.php
+++ b/overrides/tormjens/eventy/src/Action.php
@@ -14,18 +14,16 @@ class Action extends Event
      */
     public function fire($action, $args)
     {
-        if ($this->getListeners()) {
-            $this->getListeners()->where('hook', $action)->each(function ($listener) use ($action, $args) {
-                $parameters = [];
-                for ($i = 0; $i < $listener['arguments']; $i++) {
-                    if (isset($args[$i])) {
-                        $parameters[] = $args[$i];
-                    } else {
-                        $parameters[] = null;
-                    }
+        foreach ($this->getListeners($action) as $listener) {
+            $parameters = [];
+            for ($i = 0; $i < $listener['arguments']; $i++) {
+                if (isset($args[$i])) {
+                    $parameters[] = $args[$i];
+                } else {
+                    $parameters[] = null;
                 }
-                call_user_func_array($this->getFunction($listener['callback']), $parameters);
-            });
+            }
+            call_user_func_array($this->getFunction($listener['callback']), $parameters);
         }
     }
 }

--- a/overrides/tormjens/eventy/src/Event.php
+++ b/overrides/tormjens/eventy/src/Event.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace TorMorten\Eventy;
+
+abstract class Event
+{
+    /**
+     * Holds the event listeners.
+     *
+     * @var array
+     */
+    protected $listeners = [];
+
+    public function __construct()
+    {
+
+    }
+
+    /**
+     * Adds a listener.
+     *
+     * @param string $hook      Hook name
+     * @param mixed  $callback  Function to execute
+     * @param int    $priority  Priority of the action
+     * @param int    $arguments Number of arguments to accept
+     */
+    public function listen($hook, $callback, $priority = 20, $arguments = 1)
+    {
+        $this->listeners[$hook][] = [
+            'callback'  => $callback,
+            'priority'  => $priority,
+            'arguments' => $arguments,
+        ];
+        usort($listeners[$hook], function ($a, $b) {
+            return $a['priority'] - $b['priority'];
+        });
+
+        return $this;
+    }
+
+    /**
+     * Removes a listener.
+     *
+     * @param string $hook     Hook name
+     * @param mixed  $callback Function to execute
+     * @param int    $priority Priority of the action
+     */
+    public function remove($hook, $callback, $priority = 20)
+    {
+        if (isset($this->listeners[$hook])) {
+            foreach ($this->listeners[$hook] as $key => $listener) {
+                if ($listener['callback'] == $callback && $listener['priority'] == $priority) {
+                    unset($this->listeners[$hook][$key]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Remove all listeners with given hook in collection. If no hook, clear all listeners.
+     *
+     * @param string $hook Hook name
+     */
+    public function removeAll($hook = null)
+    {
+        if ($hook) {
+            if (isset($this->listeners[$hook])) {
+                unset($this->listeners[$hook]);
+            }
+        } else {
+            $this->listeners = [];
+        }
+    }
+
+    /**
+     * Gets a sorted list of all listeners.
+     *
+     * @return array
+     */
+    public function getListeners($hook)
+    {
+        if (isset($this->listeners[$hook])) {
+            $listeners = $this->listeners[$hook];
+
+            return $listeners;
+        }
+
+        return [];
+    }
+
+    /**
+     * Gets the function.
+     *
+     * @param mixed $callback Callback
+     *
+     * @return mixed A closure, an array if "class@method" or a string if "function_name"
+     */
+    protected function getFunction($callback)
+    {
+        if (is_string($callback) && strpos($callback, '@')) {
+            $callback = explode('@', $callback);
+
+            return [app('\\'.$callback[0]), $callback[1]];
+        } elseif (is_callable($callback)) {
+            return $callback;
+        } else {
+            throw new Exception('$callback is not a Callable', 1);
+        }
+    }
+
+    /**
+     * Fires a new action.
+     *
+     * @param string $action Name of action
+     * @param array  $args   Arguments passed to the action
+     */
+    abstract public function fire($action, $args);
+}

--- a/overrides/tormjens/eventy/src/Event.php
+++ b/overrides/tormjens/eventy/src/Event.php
@@ -31,7 +31,7 @@ abstract class Event
             'priority'  => $priority,
             'arguments' => $arguments,
         ];
-        usort($listeners[$hook], function ($a, $b) {
+        usort($this->listeners[$hook], function ($a, $b) {
             return $a['priority'] - $b['priority'];
         });
 

--- a/overrides/tormjens/eventy/src/Filter.php
+++ b/overrides/tormjens/eventy/src/Filter.php
@@ -17,16 +17,14 @@ class Filter extends Event
     public function fire($action, $args)
     {
         $this->value = isset($args[0]) ? $args[0] : ''; // get the value, the first argument is always the value
-        if ($this->getListeners()) {
-            $this->getListeners()->where('hook', $action)->each(function ($listener) use ($action, $args) {
-                $parameters = [];
-                $args[0] = $this->value;
-                for ($i = 0; $i < $listener['arguments']; $i++) {
-                    $value = $args[$i] ?? null;
-                    $parameters[] = $value;
-                }
-                $this->value = call_user_func_array($this->getFunction($listener['callback']), $parameters);
-            });
+        foreach ($this->getListeners($action) as $listener) {
+            $parameters = [];
+            $args[0] = $this->value;
+            for ($i = 0; $i < $listener['arguments']; $i++) {
+                $value = $args[$i] ?? null;
+                $parameters[] = $value;
+            }
+            $this->value = call_user_func_array($this->getFunction($listener['callback']), $parameters);
         }
 
         return $this->value;


### PR DESCRIPTION
Freescout appears to use `Eventy` to allow modules to customize certain aspects of freescout, for example the user `getFullName`:

https://github.com/freescout-helpdesk/freescout/blob/40fc84546168c7fed1eacf55759ff008371815f4/app/User.php#L216

Unfortunately, this eventy library appears to be quite inefficient, especially when you have large amounts of listeners (it does a `O(n)` search through _all_ listeners globally to find matching ones, plus each time does a `O(n log n)` sort by priority).

For example, on an instance I was profiling, there were ~120 listeners, thus making a single (!) `User::getFullName` take a whopping 3ms (with ~100 `getFullName` calls for listing assignable users this has a major impact; and that's just for the `getFullName` calls).

This PR overrides Eventy, to replace its internal data structure to be more efficient (keyed by the hook).

In total, this reduced mailbox loading times for my organization from ~1.5s to ~0.5s.

Note: I barely know PHP (in fact most of this code was generated by Copilot), so the code probably is very bad ^^ If there's something that can be done better let me know.

Also note that technically I'm changing the (public) `getListeners` function argument types here. This method only appears to be used inside Eventy, but this could still cause problems (it works on my instance though).