### PR TITLE
Fix module translation file never imported under certain condition.

### DIFF
--- a/overrides/barryvdh/laravel-translation-manager/src/Manager.php
+++ b/overrides/barryvdh/laravel-translation-manager/src/Manager.php
@@ -144,12 +144,12 @@ class Manager
                 if (strpos($jsonTranslationFile, '.json') === false) {
                     continue;
                 }
+
+                $locale = basename($jsonTranslationFile, '.json');
                 // Miss incorrect locales.
                 if (!preg_match('/^[a-zA-Z_]+$/', $locale)) {
                     continue;
                 }
-
-                $locale = basename($jsonTranslationFile, '.json');
 
                 $group = '_'.$module->getAlias();
 


### PR DESCRIPTION
set $locale before preg_match.because if former foreach ended contine condition.  module translation file would be never importerd.
