### PR TITLE
Allowing updates for third party modules

### DIFF
--- a/app/Console/Commands/ModuleUpdate.php
+++ b/app/Console/Commands/ModuleUpdate.php
@@ -94,49 +94,64 @@ class ModuleUpdate extends Command
             }
         }
 
+        // Loop through each installed module
         foreach ($installed_modules as $module) {
+            // Skip if the module is an official one
             if (\App\Module::isOfficial($module->get('authorUrl'))) {
                 continue;
             }
 
+            // Get the URL for the latest version of the module
             $latest_version_number_url = $module->get('latestVersionUrl');
             if (! $latest_version_number_url) {
                 continue;
             }
 
+            // Create a new Guzzle HTTP client
             $client = new \GuzzleHttp\Client();
 
             try {
+                // Send a GET request to the latest version URL
                 $response = $client->request('GET', $latest_version_number_url, \Helper::setGuzzleDefaultOptions());
 
+                // Get the latest version number from the response body
                 $latest_version = trim((string) $response->getBody());
 
                 if (empty($latest_version)) {
                     continue;
                 } else {
+                    // Get the current version of the module
                     $current_version = $module->get('version');
                 }
             } catch (\Exception $e) {
+                // If there's an exception, skip to the next iteration
                 continue;
             }
 
+            // If the latest version is greater than the current version
             if (version_compare($latest_version, $current_version, '>')) {
+                // Update the module
                 $update_result = \App\Module::updateModule($module->getAlias());
 
+                // Print the module name and status
                 $this->info('[' . $update_result['module_name'] . ' Module' . ']');
                 if ($update_result['status'] == 'success') {
+                    // If the update was successful, print the success message
                     $this->line($update_result['msg_success']);
                 } else {
+                    // If the update failed, print the error message
                     $msg = $update_result['msg'];
                     if ($update_result['download_msg']) {
                         $msg .= ' (' . $update_result['download_msg'] . ')';
                     }
                     $this->error('ERROR: ' . $msg);
                 }
+                // If there's any output from the update, print it
                 if (trim($update_result['output'])) {
                     $this->line(preg_replace("#\n#", "\n> ", '> ' . trim($update_result['output'])));
                 }
 
+                // Increment the counter
                 $counter ++;
             }
         }

--- a/app/Http/Controllers/ModulesController.php
+++ b/app/Http/Controllers/ModulesController.php
@@ -128,7 +128,7 @@ class ModulesController extends Controller
                 $modules_directory[$i_dir]['active'] = \App\Module::isActive($dir_module['alias']);
                 $modules_directory[$i_dir]['activated'] = false;
 
-                // Do not show third-party modules in Modules Derectory.
+                // Do not show third-party modules in Modules Directory.
                 if (\App\Module::isThirdParty($dir_module)) {
                     $third_party_modules[] = $modules_directory[$i_dir];
                     unset($modules_directory[$i_dir]);

--- a/app/Http/Controllers/ModulesController.php
+++ b/app/Http/Controllers/ModulesController.php
@@ -3,8 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Misc\WpApi;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
 use Illuminate\Http\Request;
 //use Nwidart\Modules\Traits\CanClearModulesCache;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -79,8 +77,8 @@ class ModulesController extends Controller
                 'activated'                    => \App\Module::isLicenseActivated($module->getAlias(), $module->get('authorUrl')),
                 'license'                      => \App\Module::getLicense($module->getAlias()),
                 // Update configuration for third party modules
-                'latestVersionNumberUrl'       => $module->get( 'latestVersionUrl' ),
-                'latestVersionZipUrl'          => $module->get( 'latestVersionZipUrl' ),
+                'latestVersionNumberUrl'       => $module->get('latestVersionUrl'),
+                'latestVersionZipUrl'          => $module->get('latestVersionZipUrl'),
                 // Determined later
                 'new_version'        => '',
             ];
@@ -143,42 +141,40 @@ class ModulesController extends Controller
             $modules_directory = [];
         }
 
-        foreach ( $installed_modules as $i_installed => $module ) {
-            if ( \App\Module::isOfficial( $module['authorUrl'] ) ) {
+        foreach ($installed_modules as $i_installed => $module) {
+            if (\App\Module::isOfficial($module['authorUrl'])) {
                 continue;
             }
 
             $latest_version_number_url = $module['latestVersionNumberUrl'] ?? null;
-            if ( ! $latest_version_number_url ) {
+            if (! $latest_version_number_url) {
                 continue;
             }
 
-            $client = new Client();
+            $client = new \GuzzleHttp\Client();
 
             try {
-                $response = $client->request( 'GET', $latest_version_number_url, [
-                    'timeout' => 2, // Timeout in seconds
-                ] );
+                $response = $client->request('GET', $latest_version_number_url, \Helper::setGuzzleDefaultOptions());
 
-                $latest_version = trim( (string) $response->getBody() );
+                $latest_version = trim((string) $response->getBody());
 
-                if ( empty( $latest_version ) ) {
+                if (empty($latest_version)) {
                     continue;
                 } else {
                     $current_version = $module['version'];
                 }
-            } catch ( RequestException $e ) {
+            } catch (\Exception $e) {
                 continue;
             }
 
-            if ( version_compare( $latest_version, $current_version, '>' ) ) {
+            if (version_compare($latest_version, $current_version, '>')) {
                 $installed_modules[ $i_installed ]['new_version'] = $latest_version;
                 $updates_available                                = true;
             }
         }
 
         // Check modules symlinks. Somestimes instead of symlinks folders with files appear.
-        
+
         $invalid_symlinks = \App\Module::checkSymlinks(
             collect($installed_modules)->where('active', true)->pluck('alias')->toArray()
         );

--- a/app/Http/Controllers/ModulesController.php
+++ b/app/Http/Controllers/ModulesController.php
@@ -141,40 +141,50 @@ class ModulesController extends Controller
             $modules_directory = [];
         }
 
+        // Loop through each installed module
         foreach ($installed_modules as $i_installed => $module) {
+            // Check if the module is an official one
             if (\App\Module::isOfficial($module['authorUrl'])) {
                 continue;
             }
 
+            // Get the URL for the latest version of the module
             $latest_version_number_url = $module['latestVersionNumberUrl'] ?? null;
             if (! $latest_version_number_url) {
                 continue;
             }
 
+            // Create a new Guzzle HTTP client
             $client = new \GuzzleHttp\Client();
 
             try {
+                // Send a GET request to the latest version URL
                 $response = $client->request('GET', $latest_version_number_url, \Helper::setGuzzleDefaultOptions());
 
+                // Get the latest version number from the response body
                 $latest_version = trim((string) $response->getBody());
 
                 if (empty($latest_version)) {
                     continue;
                 } else {
+                    // Get the current version of the module
                     $current_version = $module['version'];
                 }
             } catch (\Exception $e) {
+                // If there's an exception, skip to the next iteration
                 continue;
             }
 
+            // If the latest version is greater than the current version
             if (version_compare($latest_version, $current_version, '>')) {
+                // Update the installed module's version
                 $installed_modules[ $i_installed ]['new_version'] = $latest_version;
-                $updates_available                                = true;
+                // Set the flag to indicate that updates are available
+                $updates_available = true;
             }
         }
 
         // Check modules symlinks. Somestimes instead of symlinks folders with files appear.
-
         $invalid_symlinks = \App\Module::checkSymlinks(
             collect($installed_modules)->where('active', true)->pluck('alias')->toArray()
         );

--- a/app/Module.php
+++ b/app/Module.php
@@ -401,6 +401,7 @@ class Module extends Model
 
         // Download new version.
         if (!$result['msg']) {
+            // Check if the module's author is officially recognized
             if (self::isOfficial($module->author_url)) {
                 $params = [
                     'license'      => self::getLicense($alias),
@@ -416,6 +417,7 @@ class Module extends Model
                 } elseif (!empty($license_details['required_app_version']) && !\Helper::checkAppVersion($license_details['required_app_version'])) {
                     $result['msg'] = 'Module requires app version:'.' '.$license_details['required_app_version'];
                 } elseif (!empty($license_details['download_link'])) {
+                    // If a download link is available, proceed to update the module from the URL
                     self::updateFromUrl($module, $license_details['download_link'], $result);
                 } elseif ($license_details['status'] && $result['msg'] = self::getErrorMessage($license_details['status'])) {
                     //$result['msg'] = ;
@@ -423,11 +425,14 @@ class Module extends Model
                     $result['msg'] = __('Error occurred').': '.json_encode($license_details);
                 }
             } else {
+                // If the module's author is not officially recognized, check for a direct download link
                 $latest_version_zip_url = $module->latestVersionZipUrl ?? null;
 
-                if (! empty($latest_version_zip_url)) {
+                if (!empty($latest_version_zip_url)) {
+                    // Update the module from the provided ZIP URL
                     self::updateFromUrl($module, $module->latestVersionZipUrl, $result);
                 } else {
+                    // If no download link is available, set an error message indicating the module cannot be downloaded
                     $result['msg'] = __('Error occurred') . ': module not available for download';
                 }
             }
@@ -464,6 +469,15 @@ class Module extends Model
         return $result;
     }
 
+    /**
+     * Updates a module from a given URL.
+     *
+     * @param Module $module The module to be updated.
+     * @param string $url The URL where the new version of the module can be downloaded.
+     * @param array $result An associative array to store the result of the update operation.
+     *
+     * @return void
+     */
     private static function updateFromUrl($module, $url, &$result)
     {
         $alias = $module->alias;

--- a/app/Module.php
+++ b/app/Module.php
@@ -401,7 +401,7 @@ class Module extends Model
 
         // Download new version.
         if (!$result['msg']) {
-            if ( self::isOfficial( $module->author_url ) ) {
+            if (self::isOfficial($module->author_url)) {
                 $params = [
                     'license'      => self::getLicense($alias),
                     'module_alias' => $alias,
@@ -416,7 +416,7 @@ class Module extends Model
                 } elseif (!empty($license_details['required_app_version']) && !\Helper::checkAppVersion($license_details['required_app_version'])) {
                     $result['msg'] = 'Module requires app version:'.' '.$license_details['required_app_version'];
                 } elseif (!empty($license_details['download_link'])) {
-                    self::updateFromUrl( $module, $license_details['download_link'], $result );
+                    self::updateFromUrl($module, $license_details['download_link'], $result);
                 } elseif ($license_details['status'] && $result['msg'] = self::getErrorMessage($license_details['status'])) {
                     //$result['msg'] = ;
                 } else {
@@ -425,17 +425,16 @@ class Module extends Model
             } else {
                 $latest_version_zip_url = $module->latestVersionZipUrl ?? null;
 
-                if ( ! empty( $latest_version_zip_url ) ) {
-                    self::updateFromUrl( $module, $module->latestVersionZipUrl, $result );
+                if (! empty($latest_version_zip_url)) {
+                    self::updateFromUrl($module, $module->latestVersionZipUrl, $result);
                 } else {
-                    $result['msg'] = __( 'Error occurred' ) . ': module not available for download';
+                    $result['msg'] = __('Error occurred') . ': module not available for download';
                 }
             }
         }
 
         // Run post-update instructions.
         if (!$result['msg'] && !$result['download_error']) {
-
             $output_log = new BufferedOutput();
             \Artisan::call('freescout:module-install', ['module_alias' => $alias], $output_log);
             $result['output'] = $output_log->fetch() ?: ' ';
@@ -465,18 +464,19 @@ class Module extends Model
         return $result;
     }
 
-    private static function updateFromUrl( $module, $url, &$result ) {
+    private static function updateFromUrl($module, $url, &$result)
+    {
         $alias = $module->alias;
         // Download module.
         $module_archive = \Module::getPath() . DIRECTORY_SEPARATOR . $alias . '.zip';
 
         try {
-            \Helper::downloadRemoteFile( $url, $module_archive );
-        } catch ( \Exception $e ) {
+            \Helper::downloadRemoteFile($url, $module_archive);
+        } catch (\Exception $e) {
             $result['msg'] = $e->getMessage();
         }
 
-        if ( ! file_exists( $module_archive ) ) {
+        if (! file_exists($module_archive)) {
             $result['download_error'] = true;
         } else {
             // Extract.
@@ -486,38 +486,37 @@ class Module extends Model
                 // https://github.com/freescout-helpdesk/freescout/issues/2709
                 $public_folder = $module->getPath() . DIRECTORY_SEPARATOR . 'Public';
                 try {
-                    if ( is_link( $public_folder ) ) {
-                        unlink( $public_folder );
+                    if (is_link($public_folder)) {
+                        unlink($public_folder);
                     }
-                } catch ( \Exception $e ) {
+                } catch (\Exception $e) {
                     // Do nothing.
                 }
 
-                \Helper::unzip( $module_archive, \Module::getPath() );
-            } catch ( \Exception $e ) {
+                \Helper::unzip($module_archive, \Module::getPath());
+            } catch (\Exception $e) {
                 $result['msg'] = $e->getMessage();
             }
             // Check if extracted module exists.
             \Module::clearCache();
-            $module = \Module::findByAlias( $alias );
-            if ( ! $module ) {
+            $module = \Module::findByAlias($alias);
+            if (! $module) {
                 $result['download_error'] = true;
             }
         }
 
         // Remove archive.
-        if ( file_exists( $module_archive ) ) {
-            \File::delete( $module_archive );
+        if (file_exists($module_archive)) {
+            \File::delete($module_archive);
         }
 
-        if ( $result['download_error'] ) {
-            $result['download_msg'] = __( 'Error occurred downloading the module. Please :%a_being%download:%a_end% module manually and extract into :folder', [
+        if ($result['download_error']) {
+            $result['download_msg'] = __('Error occurred downloading the module. Please :%a_being%download:%a_end% module manually and extract into :folder', [
                 '%a_being%' => '<a href="' . $url . '" target="_blank">',
                 '%a_end%'   => '</a>',
                 'folder'    => '<strong>' . \Module::getPath() . '</strong>',
-            ] );
+            ]);
         }
-
     }
 
     public static function getErrorMessage($code, $result = null)

--- a/app/Module.php
+++ b/app/Module.php
@@ -401,70 +401,35 @@ class Module extends Model
 
         // Download new version.
         if (!$result['msg']) {
-            $params = [
-                'license'      => self::getLicense($alias),
-                'module_alias' => $alias,
-                'url'          => self::getAppUrl(),
-            ];
-            $license_details = WpApi::getVersion($params);
+            if ( self::isOfficial( $module->author_url ) ) {
+                $params = [
+                    'license'      => self::getLicense($alias),
+                    'module_alias' => $alias,
+                    'url'          => self::getAppUrl(),
+                ];
+                $license_details = WpApi::getVersion($params);
 
-            if (WpApi::$lastError) {
-                $result['msg'] = WpApi::$lastError['message'];
-            } elseif (!empty($license_details['code']) && !empty($license_details['message'])) {
-                $result['msg'] = $license_details['message'];
-            } elseif (!empty($license_details['required_app_version']) && !\Helper::checkAppVersion($license_details['required_app_version'])) {
-                $result['msg'] = 'Module requires app version:'.' '.$license_details['required_app_version'];
-            } elseif (!empty($license_details['download_link'])) {
-                // Download module.
-                $module_archive = \Module::getPath().DIRECTORY_SEPARATOR.$alias.'.zip';
-
-                try {
-                    \Helper::downloadRemoteFile($license_details['download_link'], $module_archive);
-                } catch (\Exception $e) {
-                    $result['msg'] = $e->getMessage();
-                }
-
-                if (!file_exists($module_archive)) {
-                    $result['download_error'] = true;
+                if (WpApi::$lastError) {
+                    $result['msg'] = WpApi::$lastError['message'];
+                } elseif (!empty($license_details['code']) && !empty($license_details['message'])) {
+                    $result['msg'] = $license_details['message'];
+                } elseif (!empty($license_details['required_app_version']) && !\Helper::checkAppVersion($license_details['required_app_version'])) {
+                    $result['msg'] = 'Module requires app version:'.' '.$license_details['required_app_version'];
+                } elseif (!empty($license_details['download_link'])) {
+                    self::updateFromUrl( $module, $license_details['download_link'], $result );
+                } elseif ($license_details['status'] && $result['msg'] = self::getErrorMessage($license_details['status'])) {
+                    //$result['msg'] = ;
                 } else {
-                    // Extract.
-                    try {
-                        // Sometimes by some reason Public folder becomes a symlink leading to itself.
-                        // It causes an error during updating process.
-                        // https://github.com/freescout-helpdesk/freescout/issues/2709
-                        $public_folder = $module->getPath().DIRECTORY_SEPARATOR.'Public';
-                        try {
-                            if (is_link($public_folder)) {
-                                unlink($public_folder);
-                            }
-                        } catch (\Exception $e) {
-                            // Do nothing.
-                        }
-
-                        \Helper::unzip($module_archive, \Module::getPath());
-                    } catch (\Exception $e) {
-                        $result['msg'] = $e->getMessage();
-                    }
-                    // Check if extracted module exists.
-                    \Module::clearCache();
-                    $module = \Module::findByAlias($alias);
-                    if (!$module) {
-                        $result['download_error'] = true;
-                    }
+                    $result['msg'] = __('Error occurred').': '.json_encode($license_details);
                 }
-
-                // Remove archive.
-                if (file_exists($module_archive)) {
-                    \File::delete($module_archive);
-                }
-
-                if ($result['download_error']) {
-                    $result['download_msg'] = __('Error occurred downloading the module. Please :%a_being%download:%a_end% module manually and extract into :folder', ['%a_being%' => '<a href="'.$license_details['download_link'].'" target="_blank">', '%a_end%' => '</a>', 'folder' => '<strong>'.\Module::getPath().'</strong>']);
-                }
-            } elseif ($license_details['status'] && $result['msg'] = self::getErrorMessage($license_details['status'])) {
-                //$result['msg'] = ;
             } else {
-                $result['msg'] = __('Error occurred').': '.json_encode($license_details);
+                $latest_version_zip_url = $module->latestVersionZipUrl ?? null;
+
+                if ( ! empty( $latest_version_zip_url ) ) {
+                    self::updateFromUrl( $module, $module->latestVersionZipUrl, $result );
+                } else {
+                    $result['msg'] = __( 'Error occurred' ) . ': module not available for download';
+                }
             }
         }
 
@@ -498,6 +463,61 @@ class Module extends Model
         }
 
         return $result;
+    }
+
+    private static function updateFromUrl( $module, $url, &$result ) {
+        $alias = $module->alias;
+        // Download module.
+        $module_archive = \Module::getPath() . DIRECTORY_SEPARATOR . $alias . '.zip';
+
+        try {
+            \Helper::downloadRemoteFile( $url, $module_archive );
+        } catch ( \Exception $e ) {
+            $result['msg'] = $e->getMessage();
+        }
+
+        if ( ! file_exists( $module_archive ) ) {
+            $result['download_error'] = true;
+        } else {
+            // Extract.
+            try {
+                // Sometimes by some reason Public folder becomes a symlink leading to itself.
+                // It causes an error during updating process.
+                // https://github.com/freescout-helpdesk/freescout/issues/2709
+                $public_folder = $module->getPath() . DIRECTORY_SEPARATOR . 'Public';
+                try {
+                    if ( is_link( $public_folder ) ) {
+                        unlink( $public_folder );
+                    }
+                } catch ( \Exception $e ) {
+                    // Do nothing.
+                }
+
+                \Helper::unzip( $module_archive, \Module::getPath() );
+            } catch ( \Exception $e ) {
+                $result['msg'] = $e->getMessage();
+            }
+            // Check if extracted module exists.
+            \Module::clearCache();
+            $module = \Module::findByAlias( $alias );
+            if ( ! $module ) {
+                $result['download_error'] = true;
+            }
+        }
+
+        // Remove archive.
+        if ( file_exists( $module_archive ) ) {
+            \File::delete( $module_archive );
+        }
+
+        if ( $result['download_error'] ) {
+            $result['download_msg'] = __( 'Error occurred downloading the module. Please :%a_being%download:%a_end% module manually and extract into :folder', [
+                '%a_being%' => '<a href="' . $url . '" target="_blank">',
+                '%a_end%'   => '</a>',
+                'folder'    => '<strong>' . \Module::getPath() . '</strong>',
+            ] );
+        }
+
     }
 
     public static function getErrorMessage($code, $result = null)

--- a/resources/views/modules/partials/module_card.blade.php
+++ b/resources/views/modules/partials/module_card.blade.php
@@ -11,6 +11,13 @@
 	    </p>
 	    <div class="module-details">
 		    <span>{{ __('Version') }}: {{ $module['version'] }}</span>
+            @if (!empty($module['author']))
+                @if(!empty($module['authorUrl']))
+                    | <a href="{{ $module['authorUrl'] }}" target="_blank">{{$module['author']}}</a>
+                @else
+                    | {{$module['author']}}
+                @endif
+            @endif
 		    @if (!empty($module['detailsUrl']))
 		    	| <a href="{{ $module['detailsUrl'] }}" target="_blank">{{ __('View details') }}</a>
 		    @endif


### PR DESCRIPTION
This PR adds the functionality to check the version of third party modules and update them when required.
To make it work, the following lines should be added to the modules module.json:
```json
{
...
    "latestVersionUrl": "[link to a text file containing the latest version number]",
    "latestVersionZipUrl": "[link to a zip file containing the latest module in a zip file]"
}
```

This PR also adds the author's name to the module card.