### PR TITLE
fix: optional params in setGuzzleDefaultOptions

### DIFF
--- a/app/Misc/Helper.php
+++ b/app/Misc/Helper.php
@@ -2070,7 +2070,7 @@ class Helper
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, config('app.curl_ssl_verifypeer'));        
     }
 
-    public static function setGuzzleDefaultOptions($params)
+    public static function setGuzzleDefaultOptions($params = [])
     {
         $default_params = [
             'timeout' => config('app.curl_timeout'),


### PR DESCRIPTION
Makes the params parameter in setGuzzleDefaultOptions optional. This fixes the bug in ModulesController:162 where the function is called without it and producing a fatal error. 

I made the change in ModulesController, so I could have changed it there. But I think it's better to make $params optional, since it actually is optional.