### PR TITLE
Allow limiting command freescout:fetch-emails to specific mailboxes

### DIFF
--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -31,7 +31,7 @@ class FetchEmails extends Command
      *
      * @var string
      */
-    protected $signature = 'freescout:fetch-emails {--days=3} {--unseen=1} {--identifier=dummy}';
+    protected $signature = 'freescout:fetch-emails {--days=3} {--unseen=1} {--identifier=dummy} {--mailboxes=0}';
 
     /**
      * The console command description.
@@ -97,8 +97,22 @@ class FetchEmails extends Command
         // Microseconds: 1 second = 1 000 000 microseconds.
         $sleep = 20000;
 
+        // Fetches specific mailboxes only, in case the corresponding id is greater than zero.
+        $mailboxIds = array_filter(
+            array_map(
+                'intval',
+                explode(',', $this->option('mailboxes'))
+            ),
+            function ($mailboxId) {
+                return $mailboxId > 0;
+            }
+        );
+
         foreach ($this->mailboxes as $mailbox) {
             if (!$mailbox->isInActive()) {
+                continue;
+            }
+            if ($mailboxIds !== [] && !in_array($mailbox->id, $mailboxIds, true)) {
                 continue;
             }
 


### PR DESCRIPTION
This change introduces an optional command option `mailboxes`, which can be used to limit fetching messages to particular mailbox ids.

The following example fetches all messages of the last 500 days for the specific mailboxes 5 and 7 only. By omitting the new `mailboxes` option, any message of any mailbox would have been fetched.

```
php artisan freescout:fetch-emails --mailboxes=5,7 --unseen=0 --days=500
```