### PR TITLE
Allow to set PDO::PGSQL_ATTR_DISABLE_PREPARES via environment variable

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -98,6 +98,9 @@ return [
             'prefix'   => env('DB_TABLE_PREFIX', ''),
             'schema'   => 'public',
             'sslmode'  => env('DB_PGSQL_SSLMODE', 'prefer'),
+            'options'  => extension_loaded('pdo_pgsql') ? array_filter([
+                PDO::PGSQL_ATTR_DISABLE_PREPARES => env('DB_PGSQL_ATTR_DISABLE_PREPARES'),
+            ]) : [],
         ],
 
         'sqlsrv' => [


### PR DESCRIPTION
This change allows to set the following PDO parameter for Postgresql:

> [Pdo\Pgsql::ATTR_DISABLE_PREPARES](https://www.php.net/manual/en/class.pdo-pgsql.php#pdo-pgsql.constants.attr-disable-prepares)
    Send the query and the parameters to the server together in a single call, avoiding the need to create a named prepared statement separately. If the query is only going to be executed once this can reduce latency by avoiding an unnecessary server round-trip.

`PDO::PGSQL_ATTR_DISABLE_PREPARE` is an alias of `Pdo\Pgsql::ATTR_DISABLE_PREPARES`

This made Freescout significantly faster for us.