### PR TITLE
Shorten environment variable name DB_PGSQL_ATTR_DISABLE_PREPARES

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -99,7 +99,7 @@ return [
             'schema'   => 'public',
             'sslmode'  => env('DB_PGSQL_SSLMODE', 'prefer'),
             'options'  => extension_loaded('pdo_pgsql') ? array_filter([
-                PDO::PGSQL_ATTR_DISABLE_PREPARES => env('DB_PGSQL_ATTR_DISABLE_PREPARES'),
+                PDO::PGSQL_ATTR_DISABLE_PREPARES => env('DB_PGSQL_DISABLE_PREPARES'),
             ]) : [],
         ],
 


### PR DESCRIPTION
For better readability, rename the environment variable from
`DB_PGSQL_ATTR_DISABLE_PREPARES`
to
`DB_PGSQL_DISABLE_PREPARES`

The environment variable was just added from my last PR https://github.com/freescout-help-desk/freescout/commit/35b628376b0546f8c653cca0cca87d058f3dfc66