### PR TITLE
Add module support for custom From name in outgoing emails

### DIFF
--- a/app/Mail/ReplyToCustomer.php
+++ b/app/Mail/ReplyToCustomer.php
@@ -95,38 +95,47 @@ class ReplyToCustomer extends Mailable
                     }
                 }
                 if (!empty($from_alias)) {
+                    $from_address = $from_alias;
                     $aliases = $mailbox->getAliases();
 
                     // Make sure that the From contains a mailbox alias,
                     // as user thread may have From specified when a user
                     // replies to an email notification.
                     if (array_key_exists($from_alias, $aliases)) {
-
-                        $from_alias_name = $aliases[$from_alias] ?? '';
+                        $from_name = $aliases[$from_alias] ?? '';
 
                         // Take into account mailbox From Name setting.
                         $mailbox_mail_from = $mailbox->getMailFrom($thread->created_by_user, $thread->conversation);
-                        if ($mailbox_mail_from['name'] == $mailbox->name && $from_alias_name) {
+                        if ($mailbox_mail_from['name'] == $mailbox->name && $from_name) {
                             // Use name from alias.
                         } else {
                             // User name or custom.
-                            $from_alias_name = $mailbox_mail_from['name'];
+                            $from_name = $mailbox_mail_from['name'];
                         }
-
-                        $swift_from = $headers->get('From');
-
-                        if ($from_alias_name) {
-                            $swift_from->setNameAddresses([
-                                $from_alias => $from_alias_name
-                            ]);
-                        } else {
-                            $swift_from->setAddresses([
-                                $from_alias
-                            ]);
-                        }
+                    } else {
+                        $mailbox_mail_from = $mailbox->getMailFrom($thread->created_by_user, $thread->conversation);
+                        $from_name = $mailbox_mail_from['name'];
                     }
+                } else {
+                    // No alias: use mailbox main email 
+                    $from_address = $mailbox->email;
+                    $mailbox_mail_from = $mailbox->getMailFrom($thread->created_by_user, $thread->conversation);
+                    $from_name = $mailbox_mail_from['name'];
                 }
 
+                // Allow modules to modify the display name (From Name) only
+                $from_name = \Eventy::filter('email.reply_to_customer.from_name', $from_name, $thread, $mailbox, $from_address);
+
+                $swift_from = $headers->get('From');
+                if ($from_name) {
+                    $swift_from->setNameAddresses([
+                        $from_address => $from_name
+                    ]);
+                } else {
+                    $swift_from->setAddresses([
+                        $from_address
+                    ]);
+                }
                 if ($mailbox->imap_sent_folder) {
                     \MailHelper::$smtp_mime_message = $swiftmessage->toString();
                 }
@@ -135,8 +144,8 @@ class ReplyToCustomer extends Mailable
             });
         }
 
-        $template_html = \Eventy::filter('email.reply_to_customer.template_name_html','emails/customer/reply_fancy');
-        $template_text = \Eventy::filter('email.reply_to_customer.template_name_text','emails/customer/reply_fancy_text');
+        $template_html = \Eventy::filter('email.reply_to_customer.template_name_html', 'emails/customer/reply_fancy');
+        $template_text = \Eventy::filter('email.reply_to_customer.template_name_text', 'emails/customer/reply_fancy_text');
 
         // from($this->from) Sets only email, name stays empty.
         // So we set from in Mail::setMailDriver
@@ -149,7 +158,7 @@ class ReplyToCustomer extends Mailable
                 if ($attachment->fileExists()) {
                     $message->attach($attachment->getLocalFilePath());
                 } else {
-                    \Log::error('[ReplyToCustomer] Thread: '.$thread->id.'. Attachment file not find on disk: '.$attachment->getLocalFilePath());
+                    \Log::error('[ReplyToCustomer] Thread: ' . $thread->id . '. Attachment file not find on disk: ' . $attachment->getLocalFilePath());
                 }
             }
         }


### PR DESCRIPTION
This PR adds the email.reply_to_customer.from_name filter hook to allow modules to customize the From name in email replies. The additional code changes are necessary to preserve the core functionality and ensure proper handling of From names when no module is present.



