### PR TITLE
Fix CacheBasedSessionHandler PHP >= 8.1 compatibility for SESSION_DRIVER=redis

### DIFF
--- a/overrides/laravel/framework/src/Illuminate/Session/CacheBasedSessionHandler.php
+++ b/overrides/laravel/framework/src/Illuminate/Session/CacheBasedSessionHandler.php
@@ -37,6 +37,7 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function open($savePath, $sessionName)
     {
         return true;
@@ -45,6 +46,7 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function close()
     {
         return true;
@@ -53,6 +55,7 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function read($sessionId)
     {
         return $this->cache->get($sessionId, '');
@@ -61,6 +64,7 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function write($sessionId, $data)
     {
         return $this->cache->put($sessionId, $data, $this->minutes);
@@ -69,6 +73,7 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function destroy($sessionId)
     {
         return $this->cache->forget($sessionId);
@@ -77,6 +82,7 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function gc($lifetime)
     {
         return true;


### PR DESCRIPTION
This pull request makes the _CacheBasedSessionHandler_ compatible with PHP >= 8.1 (tested up to PHP 8.3.27)

```
production.ERROR: During inheritance of SessionHandlerInterface: Uncaught ErrorException: Return type of Illuminate\Session\CacheBasedSessionHandler::open($savePath, $sessionName) should either be compatible with SessionHandlerInterface::open(string $path, string $name): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/laravel/framework/src/Illuminate/Session/CacheBasedSessionHandler.php:40
```

The _CacheBasedSessionHandler_ is used by  SESSION_DRIVER=redis and partly fixes this related issue https://github.com/freescout-help-desk/freescout/issues/4650

I use Redis/Valkey to store cache, queue and session with this Freescout Module: https://github.com/nielspeen/RedisDriver

If the default file session driver is used _CacheBasedSessionHandler_ is not relevant and this change does not affect the default configuration.
