### PR TITLE
Version 2 - #4644 Removed CSS Style on Social Profiles / Added additional class to social profiles blade

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1475,6 +1475,11 @@ https://github.com/freescout-help-desk/freescout/issues/4354
     top: 0;
     left: 92px;*/
 }
+.social-profiles-few{
+    position: absolute;
+    top: 0;
+    left: 92px;
+}
 
 .customer-social-profiles a {
     font-size: 17px;

--- a/resources/views/customers/profile_snippet.blade.php
+++ b/resources/views/customers/profile_snippet.blade.php
@@ -35,12 +35,25 @@
 	        @endforeach
 		</ul>
 		<div class="customer-extra">
-			@if ($customer->getSocialProfiles() || $customer->getWebsites())
-				<div class="customer-section customer-social-profiles">
-					@foreach ($customer->getWebsites() as $website)
+			@php
+				$socialProfiles = $customer->getSocialProfiles();
+				$websites = $customer->getWebsites();
+				$totalProfiles = count($socialProfiles) + count($websites);
+				$profileClass = 'customer-social-profiles';
+
+				if ($totalProfiles <= 10) {
+					$profileClass .= ' social-profiles-few';
+				} else {
+					$profileClass .= ' social-profiles-many';
+				}
+			@endphp
+
+			@if ($socialProfiles || $websites)
+				<div class="customer-section {{ $profileClass }}">
+					@foreach ($websites as $website)
 			            <a href="{{ $website }}" target="_blank" title="{{ parse_url($website, PHP_URL_HOST) }}" data-toggle="tooltip" class="glyphicon glyphicon-globe"></a>
 			        @endforeach
-					@foreach ($customer->getSocialProfiles() as $sp)
+					@foreach ($socialProfiles as $sp)
 			            <a href="{{ App\Customer::formatSocialProfile($sp)['value_url'] }}" target="_blank" data-toggle="tooltip" title="{{ App\Customer::formatSocialProfile($sp)['type_name'] }}" class="glyphicon glyphicon-user"></a>
 			        @endforeach
 				</div>


### PR DESCRIPTION
This suggestion places the social profiles below the emails, it looks cleaner and adopts the spacing using existing classes.

Addresses issues #4644

CSS file correctly formatted and css for social profiles class disabled

Please consider this addition. Thanks M