### PR TITLE
Add Hook Possibility of canceling email delivery

### DIFF
--- a/app/Listeners/SendReplyToCustomer.php
+++ b/app/Listeners/SendReplyToCustomer.php
@@ -49,6 +49,12 @@ class SendReplyToCustomer
             }
         }
 
+        //Possibility of canceling email delivery
+        $skipmail = \Eventy::filter('conversation.skip_send_reply_to_customer',false,$conversation,$replies);
+        if ($skipmail) {            
+             return;
+         }
+
         // Chat conversation.
         if ($conversation->isChat()) {
             \Helper::backgroundAction('chat_conversation.send_reply', [$conversation, $replies, $conversation->customer], now()->addSeconds(Conversation::UNDO_TIMOUT));


### PR DESCRIPTION
Create a new hook that allows you to cancel the sending of freescout emails if necessary.

The most practical use case is, for example, when you want to create a module to connect a channel via API.

This issue explains it better: https://github.com/freescout-help-desk/freescout/issues/5168
