### PR TITLE
Fix To header name mismatch after requester change (#3149)

### DIFF
--- a/app/Jobs/SendReplyToCustomer.php
+++ b/app/Jobs/SendReplyToCustomer.php
@@ -282,7 +282,16 @@ class SendReplyToCustomer implements ShouldQueue
         if (count($to_array) > 1) {
             $to = $to_array;
         } else {
-            $to = [['name' => $this->customer->getFullName(), 'email' => $this->customer_email]];
+            // Look up the correct customer name for the email being sent to.
+            // $this->customer may not match $this->customer_email after a requester change.
+            $to_customer_name = $this->customer->getFullName();
+            if ($this->customer_email) {
+                $email_customer = Customer::getByEmail($this->customer_email);
+                if ($email_customer) {
+                    $to_customer_name = $email_customer->getFullName();
+                }
+            }
+            $to = [['name' => $to_customer_name, 'email' => $this->customer_email]];
         }
 
         // If sending fails, all recipiens fail.


### PR DESCRIPTION
## Problem

When a conversation's requester is changed from Customer A to Customer B, outgoing reply emails use the wrong name in the `To` header:

```
To: Customer B <a@example.com>   ← wrong: Customer B's name, Customer A's email
To: Customer A <a@example.com>   ← correct
```

This happens because `SendReplyToCustomer.php` line 280 always uses `$this->customer->getFullName()` — the conversation's current requester — regardless of which customer owns `$this->customer_email`.

## Fix

Look up the customer record for the actual email being sent to via `Customer::getByEmail()` and use that customer's name. This method already exists (`app/Customer.php:1246`) and is already used in the same file at line 249.

When no requester change has occurred, `Customer::getByEmail()` returns the same customer, so behaviour is unchanged for normal replies.

## Testing

1. Change a conversation's requester from Customer A to Customer B
2. Reply to the conversation
3. Inspect the outgoing email `To` header — should show `Customer A <a@example.com>`
4. Verify normal reply flow (no requester change) is unaffected

Fixes #3149