### PR TITLE
Fix To header name mismatch after requester change (#3149)

### DIFF
--- a/app/Jobs/SendReplyToCustomer.php
+++ b/app/Jobs/SendReplyToCustomer.php
@@ -282,7 +282,16 @@ class SendReplyToCustomer implements ShouldQueue
         if (count($to_array) > 1) {
             $to = $to_array;
         } else {
-            $to = [['name' => $this->customer->getFullName(), 'email' => $this->customer_email]];
+            // Look up the correct customer name for the email being sent to.
+            // $this->customer may not match $this->customer_email after a requester change.
+            $to_customer_name = $this->customer->getFullName();
+            if ($this->customer_email) {
+                $email_customer = Customer::getByEmail($this->customer_email);
+                if ($email_customer) {
+                    $to_customer_name = $email_customer->getFullName();
+                }
+            }
+            $to = [['name' => $to_customer_name, 'email' => $this->customer_email]];
         }
 
         // If sending fails, all recipiens fail.


### PR DESCRIPTION
## Problem

When a conversation has messages from multiple customers and the requester has been changed, the outgoing reply email `To` header pairs the wrong customer name with the email address. For example: `To: Customer B <a@example.com>` instead of `To: Customer A <a@example.com>`.

This happens because `SendReplyToCustomer.php` uses `$this->customer->getFullName()` — the conversation's current requester — regardless of which customer owns `$this->customer_email`.

## Fix

Look up the customer record for the actual email being sent to via `Customer::getByEmail()`. This method already exists and is already used in the same file at line 249. Falls back to the original behaviour if no match is found.

When no requester change has occurred, `Customer::getByEmail()` returns the same customer, so behaviour is unchanged.

## Testing

1. Create a conversation from Customer A
2. Change the requester to Customer B
3. Have Customer A send another message on the conversation (so the To dropdown appears)
4. Reply selecting Customer A's email in the To field
5. Inspect the outgoing email `To` header — should show `Customer A <a@example.com>`, not `Customer B <a@example.com>`
6. Verify normal reply flow (no requester change) is unaffected

Fixes #3149