### PR TITLE
Do not throw exceptions on E_DEPRECATED warnings to fix compatibilty with newer PHP versions

### DIFF
--- a/overrides/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/overrides/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -29,7 +29,7 @@ class HandleExceptions
     {
         $this->app = $app;
 
-        error_reporting(-1);
+        error_reporting(E_ALL & ~E_DEPRECATED);
 
         set_error_handler([$this, 'handleError']);
 


### PR DESCRIPTION
Currently E_DEPRECATED warnings are handled like fatal errors in Freescout and exceptions are thrown. This leads to the fact that Freescout no longer works properly after major PHP updates, although they are actually only warnings.

This change silences E_DEPRECATED completely and solved issues with PHP 8.5 for my deployment. But other solutions may also be possible e.g.: don't set error_reporting at all and depend on the php setting or filter out E_DEPRECATED but still log them.

There were a lot issues and changes in the past due to this behavior: e.g.

https://github.com/freescout-help-desk/freescout/issues/5177
https://github.com/freescout-help-desk/freescout/issues/5134
https://github.com/freescout-help-desk/freescout/issues/5114
https://github.com/freescout-help-desk/freescout/issues/4979
https://github.com/freescout-help-desk/freescout/issues/4941
https://github.com/freescout-help-desk/freescout/issues/4857
https://github.com/freescout-help-desk/freescout/issues/4848