### PR TITLE
fix: Don't join machine-generated binary blobs to the message body

### DIFF
--- a/overrides/webklex/php-imap/src/Message.php
+++ b/overrides/webklex/php-imap/src/Message.php
@@ -645,6 +645,15 @@ class Message {
         if ($part->isAttachment()) {
             $this->fetchAttachment($part);
         }else{
+            // Don't fetch text/plain parts which have a Content-ID:
+            //     These parts are referenced MIME entities, usually machine-generated, and intended to stripped
+            //     from the message body.  An example are binary blobs of anti-spam data.  This assumes that no
+            //     standard mail-client assigns a Content-ID on the primary text/plain message body.
+            $partSubtype = strtolower($part->subtype ?? '');
+            if (($partSubtype === 'plain' || $partSubtype === '') && !empty($part->id)) {
+                return;
+            }
+
             $encoding = $this->getEncoding($part);
 
             $content = $this->decodeString($part->content, $part->encoding);


### PR DESCRIPTION
The bug:
- Headers that base64 encode binary blobs are added to the message body
- Decoding results in binary data in the body
- Running the body through character encoding sometimes results in valid utf-8 sequences and non-valid.  Non-valid utf-8 sequences are replaced with "�" and the resulting message body is garbled.

Headers like these:
```
...
x-ms-exchange-antispam-messagedata-0:
 =?utf-8?B?TklOMjlaRjdoVllpWExLNVY3Sis0YnFDTFZkOWVHNW9yUU9lcS9lLzNydGFi?=
 =?utf-8?B?bFF2S0d3U3RFcjFvQXV2V1JrMGZEK3BBTW90dS8rMG5peDhiVWZ1S3I2cm5Y?=
 ...
 =?utf-8?B?UklHcnlhVU5vZzBqNWJ6R2EyNFdicWVpQnJBUUQ4T0tuMjVZd2hkOVk3NHE4?=
 =?utf-8?Q?NtKwIx04wCq15?=
Content-Type: text/plain; charset="utf-8"
Content-ID:
 <0259E3039FB00E4894AED8C2F730B8F5@sct-15-20-9412-4-msonline-outlook-d13a4.templateTenant>
Content-Transfer-Encoding: base64
MIME-Version: 1.0
X-OriginatorOrg: sct-15-20-9412-4-msonline-outlook-d13a4.templateTenant
X-MS-Exchange-CrossTenant-AuthAs: Internal
...
```
lead to this (in the summary line, the message view, and the original message view - truncated db copy):
```
�b���u:"��3���z�����i�g�t�jd�j۬6�^q�y��c�<�t�%4�Z.��.��k�ל�*'��e���k��z0����~u�`�N�2'+���*+��ڶ*'
...
ZTY���/86YUuoIhFbhWXD5ix/unoZ0u+qMqDDlGSni5Yamig76Z����\̭��
...
```