### PR TITLE
fix(webklex): Add Header.has(), called by Part.isAttachment()

### DIFF
--- a/overrides/webklex/php-imap/src/Header.php
+++ b/overrides/webklex/php-imap/src/Header.php
@@ -119,6 +119,16 @@ class Header {
     }
 
     /**
+     * Check if a specific attribute exists
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function has($name): bool {
+        return isset($this->attributes[$name]);
+    }
+
+    /**
      * Set a specific attribute
      * @param string $name
      * @param array|mixed $value


### PR DESCRIPTION
This method does not exist and would result in a MethodNotFoundException thrown by __call().
