### PR TITLE
Add mailbox.view.sidebar_buttons hook inside sidebar buttons div

### DIFF
--- a/resources/views/mailboxes/sidebar_menu_view.blade.php
+++ b/resources/views/mailboxes/sidebar_menu_view.blade.php
@@ -28,6 +28,7 @@
                     </ul>
                 </div>
             @endif
+            @action('mailbox.view.sidebar_buttons', $mailbox)
             <a class="btn btn-trans" href="{{ route('conversations.create', ['mailbox_id' => $mailbox->id]) }}" aria-label="{{ __("New Conversation") }}" data-toggle="tooltip" title="{{ __("New Conversation") }}" role="button"><i class="glyphicon glyphicon-envelope"></i></a>
         </div>
     @endif


### PR DESCRIPTION
## Problem

There is currently no Eventy action hook inside the `.sidebar-buttons` div that
passes `$mailbox` as an argument. This makes it impossible for module developers
to cleanly inject buttons into the sidebar button group without modifying core files.

The two existing hooks have blocking limitations:

| Hook | Problem |
|---|---|
| `mailbox.view.before_name` | Receives `$mailbox`, but renders **outside** `.sidebar-buttons` — injecting a button requires fragile JS DOM manipulation |
| `mailbox.after_sidebar_buttons` | Does **not** receive `$mailbox`, and **never fires** in chat mode because it is wrapped inside `@if (!$is_in_chat_mode)` |

This leaves module developers with two bad options:

1. **Edit core files directly** — the button disappears on every FreeScout update
2. **Use `view()->getFinder()->prependLocation()`** — which works, but requires maintaining a full copy of the blade file and manually syncing it on every FreeScout release

Both approaches are fragile and create unnecessary maintenance burden.

## Solution

Add a single Eventy action hook inside `.sidebar-buttons`, immediately before the default "New Conversation" button, passing `$mailbox` as argument:

```blade
@action('mailbox.view.sidebar_buttons', $mailbox)
```

## Changed File

`resources/views/mailboxes/sidebar_menu_view.blade.php` — one line added.

## Usage Example (for module developers)

```php
\Eventy::addAction('mailbox.view.sidebar_buttons', function ($mailbox) {
    $settings = $mailbox->meta['mymodule'] ?? [];
    if (empty($settings['enabled'])) {
        return;
    }
    echo '<a class="btn btn-trans" href="' . route('mymodule.new', ['mailbox_id' => $mailbox->id]) . '"
             aria-label="New conversation"
             data-toggle="tooltip"
             title="New conversation"
             role="button">
            <img src="/modules/mymodule/img/icon.png" width="16">
          </a>';
}, 20);
```

## Impact

- No breaking changes
- No behavior change for existing installations (zero output unless a module registers a listener)
- No new dependencies
- Consistent with the pattern already used by `mailbox.view.before_name` and other hooks throughout the codebase
- Enables module developers to follow the same clean hook-based approach used by all official FreeScout modules

## Context

This was identified while developing a GreenAPI(WhatsApp) integration module that needs to add a "New WhatsApp Conversation" button to the sidebar alongside the default "New Conversation" button. The same need applies to any module that integrates an alternative communication channel (Telegram, SMS, etc.).