### PR TITLE
Update Thread.php

### DIFF
--- a/app/Thread.php
+++ b/app/Thread.php
@@ -307,6 +307,11 @@ class Thread extends Model
         if ($body === null) {
             $body = '';
         }
+        //Skip cleaning the body and remove it as is
+		$skipCleanBody = \Eventy::filter('thread.skip_clean_body', false, $this, $body);
+		if ($skipCleanBody) {
+			return $body;
+		}
 
         // Change "background:" to "background-color:".
         // https://github.com/freescout-helpdesk/freescout/issues/2560


### PR DESCRIPTION
Add a hook in case you want to bypass HTML sanitization in a particular module. I’ve encountered situations where emails didn’t display properly due to this sanitization—specifically, the HTML buttons in the notifications sent to me by Manomano were disappearing. That’s why I need to add this hook so that future updates don’t break my current code.

