### PR TITLE
Fix RTL: onoffswitch clicks no longer scroll the page to the left

### DIFF
--- a/public/css/style-rtl.css
+++ b/public/css/style-rtl.css
@@ -498,3 +498,32 @@ table.dataTable thead .sorting {
         margin-top: 0.5em !important;
     }
 }
+
+/**
+ Fix: In RTL, clicking the onoffswitch label moves focus to the hidden
+ checkbox positioned at left:-9999px, which causes the browser to scroll
+ the whole page to the left. Hide it without off-screen positioning.
+*/
+.onoffswitch-checkbox {
+        left: auto;
+        right: auto;
+        width: 1px;
+        height: 1px;
+        opacity: 0;
+        clip: rect(0 0 0 0);
+        overflow: hidden;
+        margin: 0;
+        padding: 0;
+        border: 0;
+}
+
+/* Mirror the knob: in LTR it slides from right:19px (off) to right:0 (on).
+   In RTL the label is visually mirrored, so anchor the knob to the left. */
+.onoffswitch-label:before {
+        left: 19px;
+        right: auto;
+}
+.onoffswitch-checkbox:checked + .onoffswitch-label:before {
+        left: 0;
+        right: auto;
+}


### PR DESCRIPTION
Fixes #5352.

## Summary

In RTL locales, clicking any on/off switch (Settings → General, Alerts, Mailbox → Auto Reply, etc.) caused the whole page to jump to the left because the hidden checkbox sits at `left: -9999px` and browsers scroll horizontally to bring the focused element into view.

## Changes

**public/css/style-rtl.css:**

- **Hide the checkbox without off-screen positioning.** Replace `left: -9999px` positioning (inherited from style.css) with an accessible visually-hidden pattern (`width: 1px; height: 1px; opacity: 0; clip: rect(0 0 0 0)`). This prevents the browser from ever scrolling to the "focused" hidden input.
- **Mirror the knob animation.** The LTR rule slides the knob from `right: 19px` (off) to `right: 0` (on). In RTL the switch is visually mirrored, so the knob now slides from `left: 19px` to `left: 0`.
## Notes

- Only `public/css/style-rtl.css` is changed; LTR behavior is untouched.
- The fix could also be applied to `style.css` so LTR benefits from the improved hiding technique (the focus-scroll issue technically exists in LTR too, just less visibly). Happy to do that in a follow-up PR if preferred.
## Testing

Reproduced on Chrome, Firefox, and Edge in Hebrew locale. After the fix, toggling any switch does not affect scroll position, and the knob animates in the correct direction.