### PR TITLE
Apply DB table prefix to customer/conversation search raw-SQL (3 sites)

### DIFF
--- a/app/Conversation.php
+++ b/app/Conversation.php
@@ -2346,7 +2346,7 @@ class Conversation extends Model
                     //->orWhere('conversations.id', $q_int)
 					->orWhere('customers.first_name', $like_op, $like)
                     ->orWhere('customers.last_name', $like_op, $like)
-                    ->orWhere(\Helper::isPgSql() ? \DB::raw('(customers.first_name || \' \' || customers.last_name)') : \DB::raw('CONCAT(customers.first_name, " ", customers.last_name)'), $like_op, $like)
+                    ->orWhere(\Helper::isPgSql() ? \DB::raw('('.\DB::getTablePrefix().'customers.first_name || \' \' || '.\DB::getTablePrefix().'customers.last_name)') : \DB::raw('CONCAT('.\DB::getTablePrefix().'customers.first_name, " ", '.\DB::getTablePrefix().'customers.last_name)'), $like_op, $like)
                     ->orWhere('threads.body', $like_op, $like)
                     ->orWhere('threads.from', $like_op, $like)
                     ->orWhere('threads.to', $like_op, $like)

--- a/app/Http/Controllers/ConversationsController.php
+++ b/app/Http/Controllers/ConversationsController.php
@@ -3095,7 +3095,7 @@ class ConversationsController extends Controller
 
                 $query->where('customers.first_name', $like_op, $like)
                     ->orWhere('customers.last_name', $like_op, $like)
-                    ->orWhere(\Helper::isPgSql() ? \DB::raw('(customers.first_name || \' \' || customers.last_name)') : \DB::raw('CONCAT(customers.first_name, " ", customers.last_name)'), $like_op, $like)
+                    ->orWhere(\Helper::isPgSql() ? \DB::raw('('.\DB::getTablePrefix().'customers.first_name || \' \' || '.\DB::getTablePrefix().'customers.last_name)') : \DB::raw('CONCAT('.\DB::getTablePrefix().'customers.first_name, " ", '.\DB::getTablePrefix().'customers.last_name)'), $like_op, $like)
                     ->orWhere('customers.company', $like_op, $like)
                     ->orWhere('customers.job_title', $like_op, $like)
                     ->orWhere('customers.websites', $like_op, $like)

--- a/app/Http/Controllers/ConversationsController.php
+++ b/app/Http/Controllers/ConversationsController.php
@@ -3082,7 +3082,7 @@ class ConversationsController extends Controller
         $like = '%'.mb_strtolower($q).'%';
 
         // We need to use aggregate function for email to avoid "Grouping error" error in PostgreSQL.
-        $query_customers = Customer::select(['customers.*', \DB::raw('MAX(emails.email)')])
+        $query_customers = Customer::select(['customers.*', \DB::raw('MAX('.\DB::getTablePrefix().'emails.email)')])
             ->groupby('customers.id')
             ->leftJoin('emails', function ($join) {
                 $join->on('customers.id', '=', 'emails.customer_id');

--- a/app/Http/Controllers/CustomersController.php
+++ b/app/Http/Controllers/CustomersController.php
@@ -317,7 +317,7 @@ class CustomersController extends Controller
         if ($join_emails) {
             if ($limited_visibility) {
                 // https://github.com/freescout-help-desk/freescout/issues/5032
-                $select_list[] = \DB::raw('MAX(emails.email)');
+                $select_list[] = \DB::raw('MAX('.\DB::getTablePrefix().'emails.email)');
             } else {
                 $select_list[] = 'emails.email';
             }


### PR DESCRIPTION
## Bug

On installs configured with `DB_PREFIX`, three raw-SQL fragments in the customer-search and conversation-search code paths reference table names without applying the prefix. Eloquent's query builder auto-prefixes column references it controls, but `\DB::raw()` is opaque, so hardcoded table names go through unchanged. Result: every search throws `SQLSTATE[42S22] Unknown column 'customers.first_name' / 'emails.email'`.

## Repro

1. Set `DB_PREFIX=foo_` in `.env`.
2. Run any of:
   - `GET /search?mode=customers` (or with `&xs_crm=1` from the CRM module)
   - `GET /search?mode=conversations&q=anything` with a non-empty query
   - On installs with `limit_user_customer_visibility=true`, the compose-message To-field autocomplete.

All return HTTP 500.

## Fix

Inject `\DB::getTablePrefix()` into the raw expressions. `getTablePrefix()` returns `''` on installs without a prefix, so the patch is a no-op there.

Three commits, one per site:

1. **`app/Http/Controllers/ConversationsController.php:3098`** — `CONCAT(customers.first_name, ' ', customers.last_name)` in `searchCustomers()`'s WHERE clause.
2. **`app/Http/Controllers/ConversationsController.php:3085`** — `MAX(emails.email)` in `searchCustomers()`'s SELECT clause.
3. **`app/Conversation.php:2349`** — same CONCAT, in `Conversation::search()` (the conversations-mode search path).
4. **`app/Http/Controllers/CustomersController.php:320`** — `MAX(emails.email)` in `customersAjaxSearch()`'s SELECT, gated by `limit_user_customer_visibility`.

(Two of the three commits are bundled — the line 3085 fix shipped together with Conversation.php:2349 and CustomersController.php:320 in commit cb9702e.)

## Verification

Running this patch in production on a `freescout_`-prefixed install at advally.com. After all three sites were patched, `Customer::select([...\DB::raw('MAX('.\DB::getTablePrefix().'emails.email)'),...])->...->paginate(50)` returns 329 customers cleanly.

## Notes

- I opened the first commit yesterday with only the line 3098 fix — that wasn't enough; pagination's count query was OK but the data query (which uses the broken SELECT) still failed. The follow-up commit covers the other three sites and the single end-to-end paginate path.
- An audit of all `\DB::raw` usages across `app/` and `Modules/` surfaced more occurrences with the same general shape — most were safe (functions, arithmetic), but a handful in `Modules/Reports` reference `threads.*` / `conversations.*` directly. Out of scope for this PR; happy to file separately if interest.