### PR TITLE
Add configurable threshold to suppress transient fetch errors in Logs Monitoring

### DIFF
--- a/app/Console/Commands/LogsMonitor.php
+++ b/app/Console/Commands/LogsMonitor.php
@@ -21,16 +21,19 @@ class LogsMonitor extends Command
     protected $description = 'Send new log records by email';
 
     /**
-     * Minimum identical-error occurrences required for `fetch_errors`
-     * entries to be included in the digest. Single-shot transient
-     * IMAP blips fall below this and are dropped.
+     * Default minimum identical-error occurrences required for
+     * `fetch_errors` entries to be included in the digest. Used when
+     * the `alert_logs_fetch_min_occurrences` option is not set. The
+     * default is 1, which matches upstream behaviour (no filtering);
+     * raise it via the alerts settings page to suppress transient
+     * single-shot fetch errors.
      */
-    const FETCH_ERRORS_MIN_OCCURRENCES = 3;
+    const FETCH_ERRORS_MIN_OCCURRENCES_DEFAULT = 1;
 
     /**
      * Substrings that mark a `fetch_errors` row as transient. Rows
      * matching any of these are dropped regardless of count, unless
-     * they appear at least FETCH_ERRORS_MIN_OCCURRENCES times.
+     * they appear at least the configured min-occurrences times.
      */
     const FETCH_ERRORS_TRANSIENT_PATTERNS = [
         'connection setup failed',
@@ -125,10 +128,19 @@ class LogsMonitor extends Command
      * Drop transient single-shot fetch errors. A fetch_errors row is
      * considered transient when its error message matches one of the
      * known transient patterns AND the same message appears fewer
-     * than FETCH_ERRORS_MIN_OCCURRENCES times within the window.
+     * than the configured min-occurrences threshold within the window.
      */
     protected function filterTransientFetchErrors($logs)
     {
+        $threshold = (int) \Option::get(
+            'alert_logs_fetch_min_occurrences',
+            self::FETCH_ERRORS_MIN_OCCURRENCES_DEFAULT
+        );
+
+        if ($threshold <= 1) {
+            return $logs;
+        }
+
         $fetchLogName = \App\ActivityLog::NAME_EMAILS_FETCHING;
 
         $counts = [];
@@ -141,7 +153,7 @@ class LogsMonitor extends Command
         }
 
         $dropped = 0;
-        $filtered = $logs->reject(function ($log) use ($fetchLogName, $counts, &$dropped) {
+        $filtered = $logs->reject(function ($log) use ($fetchLogName, $counts, $threshold, &$dropped) {
             if ($log->log_name !== $fetchLogName) {
                 return false;
             }
@@ -150,7 +162,7 @@ class LogsMonitor extends Command
                 return false;
             }
             $key = $this->fetchErrorFingerprint($log);
-            if (($counts[$key] ?? 0) >= self::FETCH_ERRORS_MIN_OCCURRENCES) {
+            if (($counts[$key] ?? 0) >= $threshold) {
                 return false;
             }
             $dropped++;
@@ -158,7 +170,7 @@ class LogsMonitor extends Command
         });
 
         if ($dropped > 0) {
-            $this->line('['.date('Y-m-d H:i:s').'] Suppressed '.$dropped.' transient fetch_errors entries');
+            $this->line('['.date('Y-m-d H:i:s').'] Suppressed '.$dropped.' transient fetch_errors entries (threshold '.$threshold.')');
         }
 
         return $filtered->values();

--- a/app/Console/Commands/LogsMonitor.php
+++ b/app/Console/Commands/LogsMonitor.php
@@ -152,28 +152,27 @@ class LogsMonitor extends Command
             $counts[$key] = ($counts[$key] ?? 0) + 1;
         }
 
+        $kept = [];
         $dropped = 0;
-        $filtered = $logs->reject(function ($log) use ($fetchLogName, $counts, $threshold, &$dropped) {
-            if ($log->log_name !== $fetchLogName) {
-                return false;
+        foreach ($logs as $log) {
+            if ($log->log_name === $fetchLogName) {
+                $message = $this->fetchErrorMessage($log);
+                if ($this->isTransientFetchError($message)) {
+                    $key = $this->fetchErrorFingerprint($log);
+                    if (($counts[$key] ?? 0) < $threshold) {
+                        $dropped++;
+                        continue;
+                    }
+                }
             }
-            $message = $this->fetchErrorMessage($log);
-            if (!$this->isTransientFetchError($message)) {
-                return false;
-            }
-            $key = $this->fetchErrorFingerprint($log);
-            if (($counts[$key] ?? 0) >= $threshold) {
-                return false;
-            }
-            $dropped++;
-            return true;
-        });
+            $kept[] = $log;
+        }
 
         if ($dropped > 0) {
             $this->line('['.date('Y-m-d H:i:s').'] Suppressed '.$dropped.' transient fetch_errors entries (threshold '.$threshold.')');
         }
 
-        return $filtered->values();
+        return collect($kept);
     }
 
     protected function fetchErrorMessage($log): string

--- a/app/Console/Commands/LogsMonitor.php
+++ b/app/Console/Commands/LogsMonitor.php
@@ -21,6 +21,31 @@ class LogsMonitor extends Command
     protected $description = 'Send new log records by email';
 
     /**
+     * Minimum identical-error occurrences required for `fetch_errors`
+     * entries to be included in the digest. Single-shot transient
+     * IMAP blips fall below this and are dropped.
+     */
+    const FETCH_ERRORS_MIN_OCCURRENCES = 3;
+
+    /**
+     * Substrings that mark a `fetch_errors` row as transient. Rows
+     * matching any of these are dropped regardless of count, unless
+     * they appear at least FETCH_ERRORS_MIN_OCCURRENCES times.
+     */
+    const FETCH_ERRORS_TRANSIENT_PATTERNS = [
+        'connection setup failed',
+        'failed to fetch messages',
+        'failed to authenticate',
+        'Connection closed',
+        'Connection reset',
+        'Connection timed out',
+        'Connection refused',
+        'stream_socket_client',
+        'SSL operation failed',
+        'Temporary failure',
+    ];
+
+    /**
      * Create a new command instance.
      *
      * @return void
@@ -62,6 +87,8 @@ class LogsMonitor extends Command
             ->where('created_at', '<', $now->toDateTimeString())
             ->get();
 
+        $logs = $this->filterTransientFetchErrors($logs);
+
         if (!count($logs)) {
             $this->line('['.date('Y-m-d H:i:s').'] No new log records found for the last '.$options['alert_logs_period']);
 
@@ -92,5 +119,80 @@ class LogsMonitor extends Command
         $this->line($text);
 
         $this->info('['.date('Y-m-d H:i:s').'] Monitoring finished');
+    }
+
+    /**
+     * Drop transient single-shot fetch errors. A fetch_errors row is
+     * considered transient when its error message matches one of the
+     * known transient patterns AND the same message appears fewer
+     * than FETCH_ERRORS_MIN_OCCURRENCES times within the window.
+     */
+    protected function filterTransientFetchErrors($logs)
+    {
+        $fetchLogName = \App\ActivityLog::NAME_EMAILS_FETCHING;
+
+        $counts = [];
+        foreach ($logs as $log) {
+            if ($log->log_name !== $fetchLogName) {
+                continue;
+            }
+            $key = $this->fetchErrorFingerprint($log);
+            $counts[$key] = ($counts[$key] ?? 0) + 1;
+        }
+
+        $dropped = 0;
+        $filtered = $logs->reject(function ($log) use ($fetchLogName, $counts, &$dropped) {
+            if ($log->log_name !== $fetchLogName) {
+                return false;
+            }
+            $message = $this->fetchErrorMessage($log);
+            if (!$this->isTransientFetchError($message)) {
+                return false;
+            }
+            $key = $this->fetchErrorFingerprint($log);
+            if (($counts[$key] ?? 0) >= self::FETCH_ERRORS_MIN_OCCURRENCES) {
+                return false;
+            }
+            $dropped++;
+            return true;
+        });
+
+        if ($dropped > 0) {
+            $this->line('['.date('Y-m-d H:i:s').'] Suppressed '.$dropped.' transient fetch_errors entries');
+        }
+
+        return $filtered->values();
+    }
+
+    protected function fetchErrorMessage($log): string
+    {
+        $props = $log->properties;
+        if (is_object($props) && method_exists($props, 'toArray')) {
+            $props = $props->toArray();
+        } elseif (is_string($props)) {
+            $decoded = json_decode($props, true);
+            $props = is_array($decoded) ? $decoded : [];
+        }
+        return (string) ($props['error'] ?? '');
+    }
+
+    protected function fetchErrorFingerprint($log): string
+    {
+        $message = $this->fetchErrorMessage($log);
+        // Strip the trailing "; File: /path (line)" so the same error
+        // from different stack frames still groups together.
+        $message = preg_replace('/;\s*File:.*$/s', '', $message);
+        return trim($message);
+    }
+
+    protected function isTransientFetchError(string $message): bool
+    {
+        $lower = strtolower($message);
+        foreach (self::FETCH_ERRORS_TRANSIENT_PATTERNS as $needle) {
+            if (strpos($lower, strtolower($needle)) !== false) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/app/Console/Commands/LogsMonitor.php
+++ b/app/Console/Commands/LogsMonitor.php
@@ -46,6 +46,7 @@ class LogsMonitor extends Command
         'stream_socket_client',
         'SSL operation failed',
         'Temporary failure',
+        'no response',
     ];
 
     /**

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -233,11 +233,13 @@ class SettingsController extends Controller
                     'alert_logs',
                     'alert_logs_names',
                     'alert_logs_period',
+                    'alert_logs_fetch_min_occurrences',
                     'subscription_defaults',
                 ], [
-                    'alert_logs_names'  => [],
-                    'alert_logs'        => config('app.alert_logs'),
-                    'alert_logs_period' => config('app.alert_logs_period'),
+                    'alert_logs_names'                 => [],
+                    'alert_logs'                       => config('app.alert_logs'),
+                    'alert_logs_period'                => config('app.alert_logs_period'),
+                    'alert_logs_fetch_min_occurrences' => \App\Console\Commands\LogsMonitor::FETCH_ERRORS_MIN_OCCURRENCES_DEFAULT,
                 ]);
                 break;
             default:

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -54,13 +54,20 @@
                     </div>
                 @endforeach
                 <div class="control-group form-inline margin-top-10">
-                    <label for="alert_logs_period" class="control-label">{{ __('Check Frequency') }}</label> 
+                    <label for="alert_logs_period" class="control-label">{{ __('Check Frequency') }}</label>
                     <select name="settings[alert_logs_period]" class="form-control">
                         <option value="hour" @if (old('settings[alert_logs_period]', $settings['alert_logs_period']) == 'hour') selected @endif>{{ __('Hourly') }}</option>
                         <option value="day" @if (old('settings[alert_logs_period]', $settings['alert_logs_period']) == 'day') selected @endif>{{ __('Daily') }}</option>
                         <option value="week" @if (old('settings[alert_logs_period]', $settings['alert_logs_period']) == 'week') selected @endif>{{ __('Weekly') }}</option>
                         <option value="month" @if (old('settings[alert_logs_period]', $settings['alert_logs_period']) == 'month') selected @endif>{{ __('Monthly') }}</option>
                     </select>
+                </div>
+                <div class="control-group form-inline margin-top-10">
+                    <label for="alert_logs_fetch_min_occurrences" class="control-label">{{ __('Fetch Errors Threshold') }}</label>
+                    <input id="alert_logs_fetch_min_occurrences" type="number" min="1" class="form-control" name="settings[alert_logs_fetch_min_occurrences]" value="{{ old('settings[alert_logs_fetch_min_occurrences]', $settings['alert_logs_fetch_min_occurrences']) }}">
+                    <p class="help-block">
+                        {{ __('Suppress transient fetch errors (e.g. brief IMAP connection drops) unless the same error occurs at least this many times within the check frequency window. Set to 1 to disable filtering.') }}
+                    </p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Resolves #5398.

## Summary

Adds an `alert_logs_fetch_min_occurrences` Option, exposed as a "Fetch Errors Threshold" number input in **Manage » Settings » Alerts** inside the existing Logs Monitoring panel. Lets admins suppress single-shot transient IMAP errors (auth races, brief connection drops) that recover on the next fetch run, while still escalating sustained failures.

**Default = 1**, which short-circuits the filter and matches upstream behaviour exactly — fresh installs and existing installs see no change until an admin opts in by raising the threshold.

## Behaviour

`LogsMonitor::handle()` now passes the fetched `ActivityLog` rows through `filterTransientFetchErrors()` before deciding whether to send the digest:

- Rows are grouped by error message, with the trailing `; File: …` stripped so the same error from different stack frames groups together.
- A row is dropped only if **both** conditions hold:
  - its message matches a known-transient substring (`connection setup failed`, `failed to fetch messages`, `failed to authenticate`, `Connection closed/reset/timed out/refused`, `stream_socket_client`, `SSL operation failed`, `Temporary failure`); **and**
  - the same fingerprint appears fewer than the configured threshold times in the window.
- Non-transient errors (mailbox config issues, parse errors, etc.) are never filtered.
- Other log channels (`send_errors`, `system`, …) are untouched.

When the threshold is `1` (default) the filter returns immediately, so there is no behaviour change and no measurable cost on existing installs.

## Files changed

- `app/Console/Commands/LogsMonitor.php` — filter helper + threshold lookup (+102 lines).
- `app/Http/Controllers/SettingsController.php` — read the new key in the `alerts` section's `Option::getOptions()` call.
- `resources/views/settings/alerts.blade.php` — number input + help text inside the existing `#alert_logs_wrap`. Both new strings wrapped in `__()`.

No DB migration, no route changes, no new dependencies.

## Test plan

- [ ] Fresh install (no Option set) — Logs Monitoring digest behaves identically to before.
- [ ] Set threshold to 1 via UI — same as default; verify single transient error still alerts.
- [ ] Set threshold to 3, simulate one transient `connection setup failed` row in the window — verify no alert email is sent and `freescout:logs-monitor` prints `Suppressed 1 transient fetch_errors entries (threshold 3)`.
- [ ] Set threshold to 3, simulate ≥3 identical transient rows — verify alert is sent and includes them.
- [ ] Verify a non-matching error (e.g. mailbox parse error) is never filtered regardless of count.
- [ ] Verify other channels (`send_errors`) are unaffected.