### PR TITLE
Auto-reply: send from the alias the customer emailed

### DIFF
--- a/app/Jobs/SendAutoReply.php
+++ b/app/Jobs/SendAutoReply.php
@@ -77,9 +77,23 @@ class SendAutoReply implements ShouldQueue
         $failures = [];
         $exception = null;
 
+        // Reply from the alias the customer emailed (if "Allow to reply from aliases" is enabled).
+        $from_alias = '';
+        $aliases = $this->mailbox->getAliases(true, true);
+        if (count($aliases)) {
+            $original_recipients = array_merge($this->thread->getToArray(), $this->thread->getCcArray());
+            foreach ($original_recipients as $original_recipient) {
+                $original_recipient = \App\Email::sanitizeEmail($original_recipient);
+                if ($original_recipient && array_key_exists($original_recipient, $aliases)) {
+                    $from_alias = $original_recipient;
+                    break;
+                }
+            }
+        }
+
         try {
             Mail::to([['name' => $this->customer->getFullName(), 'email' => $customer_email]])
-                ->send(new AutoReply($this->conversation, $this->mailbox, $this->customer, $headers));
+                ->send(new AutoReply($this->conversation, $this->mailbox, $this->customer, $headers, $from_alias));
         } catch (\Exception $e) {
             // We come here in case SMTP server unavailable for example
             activity()

--- a/app/Mail/AutoReply.php
+++ b/app/Mail/AutoReply.php
@@ -27,14 +27,20 @@ class AutoReply extends Mailable
     public $headers = [];
 
     /**
+     * Mailbox alias to send From (empty to use mailbox default email).
+     */
+    public $from_alias = '';
+
+    /**
      * Create a new message instance.
      */
-    public function __construct($conversation, $mailbox, $customer, $headers)
+    public function __construct($conversation, $mailbox, $customer, $headers, $from_alias = '')
     {
         $this->conversation = $conversation;
         $this->mailbox = $mailbox;
         $this->customer = $customer;
         $this->headers = $headers;
+        $this->from_alias = $from_alias;
     }
 
     /**
@@ -77,15 +83,54 @@ class AutoReply extends Mailable
     public function setHeaders()
     {
         $new_headers = $this->headers;
-        if (!empty($new_headers)) {
-            $this->withSwiftMessage(function ($swiftmessage) use ($new_headers) {
-                if (!empty($new_headers['Message-ID'])) {
-                    $swiftmessage->setId($new_headers['Message-ID']);
+        $from_alias = $this->from_alias;
+        if (!empty($new_headers) || $from_alias) {
+            $mailbox = $this->mailbox;
+            $conversation = $this->conversation;
+            $this->withSwiftMessage(function ($swiftmessage) use ($new_headers, $from_alias, $mailbox, $conversation) {
+                $headers = null;
+
+                if (!empty($new_headers)) {
+                    if (!empty($new_headers['Message-ID'])) {
+                        $swiftmessage->setId($new_headers['Message-ID']);
+                    }
+                    $headers = $swiftmessage->getHeaders();
+                    foreach ($new_headers as $header => $value) {
+                        if ($header != 'Message-ID') {
+                            $headers->addTextHeader($header, $value);
+                        }
+                    }
                 }
-                $headers = $swiftmessage->getHeaders();
-                foreach ($new_headers as $header => $value) {
-                    if ($header != 'Message-ID') {
-                        $headers->addTextHeader($header, $value);
+
+                if (!empty($from_alias)) {
+                    $aliases = $mailbox->getAliases();
+
+                    if (array_key_exists($from_alias, $aliases)) {
+                        $from_alias_name = $aliases[$from_alias] ?? '';
+
+                        // Take into account mailbox From Name setting.
+                        $mailbox_mail_from = $mailbox->getMailFrom(null, $conversation);
+                        if ($mailbox_mail_from['name'] == $mailbox->name && $from_alias_name) {
+                            // Use name from alias.
+                        } else {
+                            $from_alias_name = $mailbox_mail_from['name'];
+                        }
+
+                        if (!$headers) {
+                            $headers = $swiftmessage->getHeaders();
+                        }
+
+                        $swift_from = $headers->get('From');
+
+                        if ($from_alias_name) {
+                            $swift_from->setNameAddresses([
+                                $from_alias => $from_alias_name,
+                            ]);
+                        } else {
+                            $swift_from->setAddresses([
+                                $from_alias,
+                            ]);
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary

Currently the auto-reply is always sent from the mailbox's default email address — mailbox aliases and the "Allow to reply from aliases" (`aliases_reply`) setting are ignored on the auto-reply path. This PR makes the auto-reply behave the same way user replies already do:

- If the customer's email was sent to a mailbox alias **and** "Allow to reply from aliases" is enabled → the auto-reply is sent **from that alias** (with the configured alias display name where set).
- If `aliases_reply` is disabled, or the recipient is not one of the configured aliases → the auto-reply is sent from the **default mailbox email** (unchanged behaviour).

The implementation reuses the existing, proven alias pattern from `app/Mail/ReplyToCustomer.php` so behaviour is consistent across the app.

## Changes

- `app/Jobs/SendAutoReply.php` — match the original incoming thread's To/Cc against `Mailbox::getAliases(true, true)` (returns `[]` when `aliases_reply` is off, so the fallback to the default email is automatic) and pass the resolved alias to the `AutoReply` mailable.
- `app/Mail/AutoReply.php` — accept a `$from_alias` constructor argument and override the Swift `From` header inside the existing `withSwiftMessage` closure, mirroring the alias-handling block in `ReplyToCustomer::build()` (including From-Name precedence: alias display name only wins when the mailbox From Name is the plain mailbox name; a custom/user From Name still takes precedence).

No DB migration, config, or UI changes — `aliases`, `aliases_reply`, and the settings UI already exist.

## Test plan

- [ ] Mailbox with primary `support@x.com`, alias `sales@x.com(Sales Team)`, "Allow to reply from aliases" **enabled**, auto-reply enabled. Email `sales@x.com` → auto-reply `From:` is `Sales Team <sales@x.com>`.
- [ ] Same mailbox/alias, "Allow to reply from aliases" **disabled**. Email `sales@x.com` → auto-reply `From:` is the default `support@x.com`.
- [ ] With `aliases_reply` enabled, email an address that is **not** a configured alias → auto-reply `From:` is the default `support@x.com`.
- [ ] Email the default `support@x.com` directly → auto-reply `From:` is `support@x.com` (no regression).
- [ ] Set mailbox From Name to a custom value, repeat the alias case → custom From Name is used together with the alias address.
- [ ] `In-Reply-To`, `References`, and `Message-ID` headers are still set correctly on the auto-reply (no regression in `setHeaders`).
