### PR TITLE
Fetching: paginate by SEARCH count so the newest emails are no longer dropped (#4624)

### DIFF
--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -273,8 +273,43 @@ class FetchEmails extends Command
 
             // Requesting emails by bunches allows to fetch large amounts of emails
             // without problems with memory.
-            $page = 0;
-            do {
+            //
+            // Compute how many bunches to fetch from a plain IMAP SEARCH count up
+            // front, instead of driving the loop off the per-bunch materialized count.
+            // That avoids two bugs:
+            //  (1) Silent loss of the NEWEST emails (#4624): a single message that fails
+            //      to materialize in a batch fetch makes a bunch come back short; the old
+            //      `while (count($messages) == $page_size)` then stopped before fetching
+            //      the later bunches. With fetch_order='asc' those later bunches hold the
+            //      newest emails, so they were dropped silently.
+            //  (2) Looping "until an empty page" instead would fetch one page past the
+            //      end, and the IMAP layer throws "Array to string conversion" when asked
+            //      to fetch an empty UID list.
+            // Webklex Query::limit()/forPage() are 1-indexed, so pages start at 1.
+            //
+            // NOTE: this assumes a stable search set across pages (fetch_unseen=0). With
+            // fetch_unseen=1, processMessage() marks messages \Seen mid-loop, shrinking
+            // the unseen set between pages and shifting forPage() — a separate,
+            // pre-existing drift (#4047), not addressed here.
+            try {
+                $count_query = $folder->query()->since(now()->subDays($this->option('days')))->leaveUnread();
+                if ($unseen) {
+                    $count_query->unseen();
+                }
+                if ($no_charset) {
+                    $count_query->setCharset(null);
+                }
+                $total_messages = $count_query->count();
+            } catch (\Exception $e) {
+                // If the SEARCH count fails (e.g. charset issues on some servers), fall
+                // back to a single bunch so we never silently fetch nothing. The
+                // per-bunch charset retry below still recovers the rest on such servers.
+                $total_messages = $page_size;
+                $this->logError('Folder: '.$folder->name.'; Count error: '.$e->getMessage());
+            }
+            $total_pages = ($page_size > 0) ? (int) ceil($total_messages / $page_size) : 1;
+
+            for ($page = 1; $page <= $total_pages; $page++) {
                 // Get messages.
                 $last_error = '';
                 $messages = collect([]);
@@ -339,8 +374,7 @@ class FetchEmails extends Command
                     $dest_mailbox = \Eventy::filter('fetch_emails.mailbox_to_save_message', $mailbox, $folder);
                     $this->processMessage($message, $message_id, $dest_mailbox, $this->mailboxes);
                 }
-                $page++;
-            } while (count($messages) == $page_size);
+            }
         }
 
         $client->disconnect();


### PR DESCRIPTION
### Summary

On a busy mailbox, FreeScout can silently lose the **newest** incoming emails whenever a fetch window (`--days`) contains more messages than `fetching_bunch_size` **and** any non-final bunch fails to fully materialize. The dropped emails never appear and nothing actionable is logged. This is the problem reported in #4624 ("99 fetched instead of 100"), and is related to the pagination drift in #4047.

### Root cause

`app/Console/Commands/FetchEmails.php` drives its bunch loop off the **materialized** message count:

```php
$page = 0;
do {
    $messages_query->limit($page_size, $page); // webklex limit($limit, $page)
    $messages = $messages_query->get();
    // ... process ...
    $page++;
} while (count($messages) == $page_size);
```

Three interacting facts make this drop the newest mail:

1. **`while (count($messages) == $page_size)`** stops the loop the moment a bunch comes back with fewer than `$page_size` messages — but a bunch can come back short for reasons other than "end of mailbox" (a message that fails to materialize in the batch FETCH: malformed header, deleted between SEARCH and FETCH, etc.). One such message in an early bunch ends the loop **before the later bunches are ever fetched**.
2. **`fetch_order` defaults to `asc`** (oldest first), so the never-fetched later bunches are exactly the **newest** emails.
3. The loop starts at **`$page = 0`**, but webklex `Query::limit($limit, $page)` is **1-indexed** (`if ($page >= 1) $this->page = $page;`, default `1`) and `fetch()` uses `forPage($this->page, $this->limit)`. So `limit($size, 0)` is a no-op for the page and collapses to page 1 — the first bunch is fetched twice (harmless thanks to Message-ID dedup, but it confirms the off-by-one).

### Reproduction

- Mailbox with a 3-day window of ~106 messages, `fetching_bunch_size = 100`.
- One message in the first bunch fails to materialize in the batch FETCH → the bunch returns 99.
- `99 != 100` → the loop stops after the first bunch. The newest messages (the second bunch) are **never fetched** and silently lost.

### Fix

Compute how many bunches to fetch from a plain IMAP **SEARCH count** (no message bodies materialized), then iterate exactly `ceil(total / page_size)` 1-indexed pages. The loop is no longer driven by the fragile per-bunch materialized count:

```php
$total_messages = $folder->query()->since(...)->leaveUnread()->count(); // plain SEARCH
$total_pages    = ($page_size > 0) ? (int) ceil($total_messages / $page_size) : 1;
for ($page = 1; $page <= $total_pages; $page++) {
    // ... unchanged bunch body: limit($page_size, $page)->get(); process ...
}
```

### Why not `while (count($messages) > 0)`?

The obvious alternative — paginate until a page comes back empty — looks simpler but **introduces a crash**: terminating that way requires fetching one page *past* the end, and `forPage()` then returns an empty UID list. `ImapProtocol::fetch()` builds the message set as `$from . ':' . $from` with `$from = []`, throwing **`Array to string conversion`** on every fetch run. Counting up front never fetches an empty page, so it avoids both the data loss and this crash. (Alternatively, the empty UID list could be guarded inside `Query::fetch()` — happy to split that out if preferred.)

### Scope / caveats

- This fixes the loss for a **stable** search set (i.e. `fetch_unseen = 0`). With `fetch_unseen = 1`, `processMessage()` marks messages `\Seen` mid-loop, shrinking the unseen set between pages and shifting `forPage()` — the separate, pre-existing drift from #4047. That is not addressed here and is flagged in a code comment.
- The per-bunch charset fallback (#176) is preserved unchanged; the new `count()` mirrors the same `unseen` / `setCharset` conditions and falls back to a single bunch if the SEARCH itself fails.

### Testing

Validated read-only (IMAP PEEK, no writes) against a live high-volume mailbox: with the bunch size forced to 100 and 50, the old loop reaches 99/106 (drops the 7 newest); the count-based loop reaches 106/106 with no crash. An item-by-item probe confirmed all messages materialize individually (no intrinsically poisoned message — the short bunch is a transient batch-FETCH failure). Also exercised end-to-end with `fetching_bunch_size = 50` forcing 3 pages: all pages processed, no `Array to string conversion`.

Refs #4624, #4047
