### PR TITLE
Fix 500 in ConversationsController::view when the user has no Mine folder

### DIFF
--- a/app/Http/Controllers/ConversationsController.php
+++ b/app/Http/Controllers/ConversationsController.php
@@ -99,7 +99,10 @@ class ConversationsController extends Controller
 
                     \Session::reflash();
 
-                    return redirect()->away($conversation->url($folder->id, null, $params));
+                    // A user may have no Mine folder in this mailbox (e.g. admins / non-members),
+                    // so the lookup above can return null. Fall back to the conversation's own
+                    // folder instead of throwing "Attempt to read property id on null".
+                    return redirect()->away($conversation->url($folder ? $folder->id : $conversation->folder_id, null, $params));
                 }
             }
         }
@@ -117,7 +120,8 @@ class ConversationsController extends Controller
 
             \Session::reflash();
 
-            return redirect()->away($conversation->url($folder->id));
+            // The Mine-folder lookup (or $conversation->folder) can be null; fall back to folder_id.
+            return redirect()->away($conversation->url($folder ? $folder->id : $conversation->folder_id));
         }
 
         //$after_send = $conversation->mailbox->getUserSettings($user->id)->after_send;


### PR DESCRIPTION
### Problem

Opening a conversation that is **assigned to the current user** can throw `Attempt to read property "id" on null` and return a 500.

In `ConversationsController::view()`, when the conversation is assigned to the viewing user, the code looks up that user's `TYPE_MINE` folder in the mailbox and immediately reads `$folder->id`:

```php
$folder = $conversation->mailbox->folders()
    ->where('type', Folder::TYPE_MINE)
    ->where('user_id', $user->id)
    ->first();
\Session::reflash();
return redirect()->away($conversation->url($folder->id, null, $params));
```

That lookup returns **null** when the user has no Mine folder in the mailbox, which happens for any user who is **not a member of the mailbox** (e.g. admins viewing/handling conversations in mailboxes they don't belong to). The "Add folder if empty" branch a few lines down has the same `$folder->id`-on-null risk.

### Steps to reproduce

1. Have a user who is **not** a member of a given mailbox (an admin works).
2. Assign a conversation in that mailbox to them.
3. Open the conversation via the Assigned folder.

Result: 500, `production.ERROR: Attempt to read property "id" on null` at `ConversationsController.php`.

### Fix

Guard both redirects so a null Mine-folder lookup falls back to the conversation's own folder:

```php
return redirect()->away($conversation->url($folder ? $folder->id : $conversation->folder_id, null, $params));
```

No behaviour change when a Mine folder exists. `php -l` clean. Verified against a production instance: the previously-crashing path now redirects to a valid folder URL.