### PR TITLE
feat: add Previous Message tab to Show Original modal

### DIFF
--- a/app/Http/Controllers/ConversationsController.php
+++ b/app/Http/Controllers/ConversationsController.php
@@ -2561,10 +2561,22 @@ class ConversationsController extends Controller
             }
         }
 
+        $previous_thread = null;
+        if ($thread->conversation_id) {
+            $previous_thread = Thread::where('conversation_id', $thread->conversation_id)
+                ->where('id', '<', $thread->id)
+                ->whereIn('type', [Thread::TYPE_CUSTOMER, Thread::TYPE_MESSAGE])
+                ->whereNotNull('body')
+                ->where('body', '!=', '')
+                ->orderBy('id', 'desc')
+                ->first();
+        }
+
         return view('conversations/ajax_html/show_original', [
             'thread' => $thread,
             'body_preview' => $body_preview,
             'fetched' => $fetched,
+            'previous_thread' => $previous_thread,
         ]);
     }
 

--- a/resources/views/conversations/ajax_html/show_original.blade.php
+++ b/resources/views/conversations/ajax_html/show_original.blade.php
@@ -6,6 +6,7 @@
 	<li role="presentation" class="active"><a data-toggle="tab" href="#tab_preview_{{ $tabs_unique }}">{{ __('Preview') }}</a></li>
 	<li role="presentation"><a data-toggle="tab" href="#tab_body_{{ $tabs_unique }}">{{ __('Body') }}</a></li>
 	@if ($thread->headers)<li role="presentation"><a data-toggle="tab" href="#tab_headers_{{ $tabs_unique }}">{{ __('Email Headers') }}</a></li>@endif
+	@if ($previous_thread)<li role="presentation"><a data-toggle="tab" href="#tab_previous_{{ $tabs_unique }}">{{ __('Previous Message') }}</a></li>@endif
 </ul>
 
 <div class="tab-content">
@@ -21,4 +22,17 @@
 	@if ($thread->headers)<div id="tab_headers_{{ $tabs_unique }}" class="tab-pane fade">
 		<pre class="pre-wrap">{{ $thread->headers }}</pre>
 	</div>@endif
+	@if ($previous_thread)
+	<div id="tab_previous_{{ $tabs_unique }}" class="tab-pane fade">
+		<div style="color:#888;font-size:12px;padding:6px 0 8px;border-bottom:1px solid #eee;margin-bottom:10px;">
+			<strong>{{ $previous_thread->type == \App\Thread::TYPE_CUSTOMER ? __('Customer') : __('Agent') }}</strong>
+			&mdash;
+			{{ $previous_thread->created_at ? $previous_thread->created_at->format('d/m/Y H:i') : '' }}
+		</div>
+		<iframe sandbox=""
+			srcdoc="{!! htmlspecialchars($previous_thread->getBodyOriginal(), ENT_QUOTES|ENT_SUBSTITUTE, 'UTF-8') !!}"
+			frameborder="0"
+			class="preview-iframe tab-body"></iframe>
+	</div>
+	@endif
 </div>


### PR DESCRIPTION
# Add "Previous Message" tab to Show Original modal

## Problem

When an agent clicks **Show Original → Body** on a customer's reply, FreeScout shows only
the body of that specific message. The quoted content from the previous message is stripped
away — by design — to keep conversations clean.

However, this creates a blind spot: **a customer can silently modify the quoted text** when
replying, and the agent has no way to verify it without accessing the raw mailbox.

### Real-world example

A common support workflow sends a pre-filled form to the customer for validation:

> *"Here are your contract details. Please reply with 'OK' to confirm, or correct anything
> that is wrong. The bank account field is missing — please add it."*

The customer replies **"OK"**, but also fills in the bank account number (or corrects a
field) inside the quoted text. With the current UI, the agent only sees "OK". They must
leave FreeScout and open the raw mailbox to find the bank account the customer provided.

## Solution

Add a **"Previous Message"** tab to the Show Original modal. It renders the preceding
customer or agent message — the one being replied to — so agents can compare both messages
side by side without leaving FreeScout.

**Changes: 2 files, ~15 lines added.**

### `app/Http/Controllers/ConversationsController.php`

In `ajaxHtmlShowOriginal()`, fetch the immediately preceding `TYPE_CUSTOMER` or
`TYPE_MESSAGE` thread in the same conversation:

```php
$previous_thread = null;
if ($thread->conversation_id) {
    $previous_thread = Thread::where('conversation_id', $thread->conversation_id)
        ->where('id', '<', $thread->id)
        ->whereIn('type', [Thread::TYPE_CUSTOMER, Thread::TYPE_MESSAGE])
        ->whereNotNull('body')
        ->where('body', '!=', '')
        ->orderBy('id', 'desc')
        ->first();
}
```

Pass it to the view: `'previous_thread' => $previous_thread`.

### `resources/views/conversations/ajax_html/show_original.blade.php`

Add a conditional tab (only shown when a previous message exists):

```blade
@if ($previous_thread)
<li role="presentation">
    <a data-toggle="tab" href="#tab_previous_{{ $tabs_unique }}">{{ __('Previous Message') }}</a>
</li>
@endif
```

And the corresponding pane, rendering the body in a sandboxed iframe (consistent with the
existing Preview tab):

```blade
@if ($previous_thread)
<div id="tab_previous_{{ $tabs_unique }}" class="tab-pane fade">
    <div style="color:#888;font-size:12px;padding:6px 0 8px;border-bottom:1px solid #eee;margin-bottom:10px;">
        <strong>{{ $previous_thread->type == \App\Thread::TYPE_CUSTOMER ? __('Customer') : __('Agent') }}</strong>
        &mdash;
        {{ $previous_thread->created_at ? $previous_thread->created_at->format('d/m/Y H:i') : '' }}
    </div>
    <iframe sandbox=""
        srcdoc="{!! htmlspecialchars($previous_thread->getBodyOriginal(), ENT_QUOTES|ENT_SUBSTITUTE, 'UTF-8') !!}"
        frameborder="0"
        class="preview-iframe tab-body"></iframe>
</div>
@endif
```

## Security

- The iframe uses `sandbox=""` (same as the existing Preview tab), blocking scripts,
  forms, and cross-origin access.
- `htmlspecialchars(..., ENT_QUOTES|ENT_SUBSTITUTE)` correctly escapes the body for
  the `srcdoc` attribute context, preventing HTML injection through the attribute parser.

## Behaviour

- The tab only appears when there is a previous message in the same conversation
  (first message in a conversation: no tab shown).
- Only `TYPE_CUSTOMER` and `TYPE_MESSAGE` threads are considered — notes and line items
  are excluded.
- No new routes, no JavaScript, no extra HTTP requests. The previous message body is
  passed directly in the initial AJAX render.

## Translation

One new string: `'Previous Message'`. FreeScout uses the English string directly as the
translation key (no `en.json` exists), so English works automatically. Other locales should
add `"Previous Message": "<translation>"` to their respective JSON files under
`resources/lang/`.