### PR TITLE
fix: prevent sending blank email when Summernote leaves empty HTML tags

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2233,7 +2233,17 @@ function initReplyForm(load_attachments, init_customer_selector, is_new_conv)
 	    	// Validate before sending
 	    	form = $(".form-reply:first");
 
-	    	if (!form.parsley().validate()) {
+	    	// Sync Summernote's empty-HTML state to the textarea before validation so that
+    	// data-parsley-required treats visually-empty content (e.g. <div><br></div>)
+    	// the same as a truly empty field (issue #4590).
+    	if (typeof $.fn.summernote !== 'undefined' && $('#body').length) {
+    		var body_code = $('#body').summernote('code');
+    		if (!$.trim(body_code.replace(/<[^>]+>/g, '').replace(/&nbsp;/gi, ''))) {
+    			$('#body').val('');
+    		}
+    	}
+
+    	if (!form.parsley().validate()) {
 	    		fs_processing_send_reply = false;
 	    		return;
 	    	}


### PR DESCRIPTION
## Problem

Closes #4590.

When a user opens the reply form, types something in the Summernote editor, and then deletes all the content, the underlying `<textarea id="body">` retains HTML residue such as `<div><br></div>`. Parsley's built-in `required` validator treats this as a non-empty value and allows the form to be submitted with a blank reply body.

## Root cause

Summernote writes its full HTML output to the hidden textarea whenever the editor content changes. An empty editor produces `<div><br></div>` (or similar) instead of an empty string, so the Parsley `required` check passes.

## Fix

Just before calling `parsley().validate()` in the reply-submit click handler, read the editor's current HTML via `summernote('code')`, strip all HTML tags and `&nbsp;` entities, and if the resulting string is empty/whitespace, reset the textarea value to `''`. This makes `data-parsley-required` (and its `data-parsley-required-message`) work correctly with no changes to any blade templates.

The check is guarded with `typeof $.fn.summernote !== 'undefined'` so it is a no-op on pages where the Summernote editor is not loaded.