### PR TITLE
Save conversation subject when pressing Enter in the subject field

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1281,6 +1281,14 @@ function initConversation()
 	    	$(this).addClass('conv-subj-editing');
 		});
 
+		// Save subject on Enter
+		jQuery("#conv-subj-value").on('keydown', function(e){
+			if (e.which == 13) {
+				e.preventDefault();
+				jQuery(".conv-subj-editor button:first").click();
+			}
+		});
+
 		// Save subject
 	    jQuery(".conv-subj-editor button:first").click(function(e){
 	    	var button = $(this);


### PR DESCRIPTION
### Problem

When editing a conversation's subject inline (clicking the subject to reveal the edit field), pressing **Enter** does nothing — the change is only saved when the user clicks the check button next to the field.

The subject `<input>` is not wrapped in a `<form>`, so there is no implicit submit, and no key handler was bound to it. In practice users type a new subject, press Enter, see the field stay as-is, and assume it saved. The old subject is then used on outgoing replies/forwards.

This is inconsistent with the reply editor, which already submits on Enter.

### Fix

Bind Enter on `#conv-subj-value` to trigger the existing save button, so the change goes through the exact same AJAX/save path as clicking the button. The check button is unchanged.

```js
// Save subject on Enter
jQuery("#conv-subj-value").on('keydown', function(e){
    if (e.which == 13) {
        e.preventDefault();
        jQuery(".conv-subj-editor button:first").click();
    }
});
```

Single file changed: `public/js/main.js`.

### Testing

Manually verified locally: clicked a conversation subject, edited the text, pressed Enter (without clicking the button), reloaded the page — the new subject was persisted. Clicking the button still works as before.

### Notes

- Enter-only (no Escape-to-cancel) to keep the change minimal; happy to add Escape handling if desired.