### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Images & one-click installs:
 * [Softaculous](http://www.softaculous.com/apps/customersupport/FreeScout) (cPanel, Plesk, ISPmanager, H-Sphere, DirectAdmin, InterWorx)
 * [Fantastico](http://ff3.netenberg.com/visitors/scripts/freescout/view) (cPanel, DirectAdmin, ISP Manager, ISP Config)
 * [Cloudron](https://cloudron.io/store/net.freescout.cloudronapp.html)
+* [![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/freescout) one-click managed hosting, no server required
 * [Ubuntu](https://github.com/freescout-help-desk/freescout/wiki/Installation-Guide#interactive-installation-bash-script-ubuntu) (bash script)
 
 ## Cloud Hosted


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added
FreeScout to our marketplace, so this PR adds a small "Deploy with Zenith" badge under Installation
(the "Images & one-click installs" list, links to https://zenith.hosting/host/freescout).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

---

PR targets the `master` branch per the repo's PR template. Docs-only change (single README line, additions-only); no tests or builds affected.
