### PR TITLE
Add On-Hold as a first-class conversation status (ARMS-12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,10 @@ Thumbs.db
 /public/css/builds/
 /public/js/builds/
 /public/.well-known
-/Modules
+/Modules/*
 /Modules/**/.git
+# Threls custom modules are version-controlled (paid modules above stay runtime-installed)
+!/Modules/OnHoldStatus
 /public/modules
 /public/docs
 /public/.dh-diag

--- a/Modules/OnHoldStatus/Providers/OnHoldStatusServiceProvider.php
+++ b/Modules/OnHoldStatus/Providers/OnHoldStatusServiceProvider.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Modules\OnHoldStatus\Providers;
+
+use App\Conversation;
+use App\Thread;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Adds On-Hold as a first-class conversation status (ARMS-12).
+ *
+ * Core hard-codes four statuses (Active/Pending/Closed/Spam) but exposes them
+ * as mutable static arrays that Blade dropdowns, validation and JS all read
+ * from — so appending a fifth status here propagates everywhere except
+ * statusCodeToName(), which is covered by the conversation.status_name
+ * filter added to core on the threls fork (see ARMS-12).
+ *
+ * Status mapping for ARMS needs only this one new status:
+ * New = Active+unassigned · Open = Active+assigned · Pending = Pending ·
+ * On-Hold = 5 (this module) · Solved = Closed.
+ */
+class OnHoldStatusServiceProvider extends ServiceProvider
+{
+    /**
+     * Status code 5 is free on both models: Conversation reserves it as a
+     * commented-out STATUS_OPEN, and Thread::STATUS_NOCHANGE already took 6.
+     */
+    const STATUS_ONHOLD = 5;
+
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = false;
+
+    /**
+     * Boot the application events.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->registerStatus();
+        $this->hooks();
+    }
+
+    /**
+     * Register the On-Hold status with core's status registries.
+     */
+    protected function registerStatus()
+    {
+        Conversation::$statuses[self::STATUS_ONHOLD] = 'onhold';
+        Conversation::$status_icons[self::STATUS_ONHOLD] = 'pause';
+        Conversation::$status_classes[self::STATUS_ONHOLD] = 'warning';
+        Conversation::$status_colors[self::STATUS_ONHOLD] = '#f39c12';
+
+        // Status codes must match between conversations and threads
+        // (see the comment above Conversation's status constants).
+        Thread::$statuses[self::STATUS_ONHOLD] = 'onhold';
+    }
+
+    /**
+     * Module hooks.
+     */
+    public function hooks()
+    {
+        // Resolves the status name for both Conversation::statusCodeToName()
+        // and Thread::statusCodeToName() (fork patch, ARMS-12).
+        \Eventy::addFilter('conversation.status_name', function ($name, $status) {
+            if ((int) $status === self::STATUS_ONHOLD) {
+                return __('On Hold');
+            }
+
+            return $name;
+        }, 20, 2);
+    }
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+    }
+}

--- a/Modules/OnHoldStatus/README.md
+++ b/Modules/OnHoldStatus/README.md
@@ -1,0 +1,72 @@
+# OnHoldStatus
+
+Adds **On-Hold** as a first-class conversation status (code `5`) for ARMS.
+Tracked as [ARMS-12](https://threls.atlassian.net/browse/ARMS-12).
+
+ARMS's status lifecycle is New/Open/Pending/**On-Hold**/Solved. Core FreeScout
+hard-codes four statuses; only On-Hold needs adding — the rest map natively
+(New = Active+unassigned, Open = Active+assigned, Solved = Closed).
+
+## How it works
+
+The service provider appends status 5 to core's mutable static registries at
+boot — `Conversation::$statuses` / `$status_icons` / `$status_classes` /
+`$status_colors` and `Thread::$statuses`. Status dropdowns (conversation view,
+search filters, bulk actions), validation, folder logic, and counters all read
+those arrays, so the status propagates with no further wiring.
+
+The status *name* resolves through the `conversation.status_name` Eventy
+filter, which this module answers with "On Hold".
+
+## ⚠ Depends on two fork patches — will not work on stock FreeScout
+
+`Conversation::statusCodeToName()` and `Thread::statusCodeToName()` are
+hardcoded switches in core. The threls fork patches their `default:` cases to
+call the `conversation.status_name` filter (see ARMS-12; grep for
+`threls fork patch` in `app/Conversation.php` / `app/Thread.php`).
+
+Installed on an unpatched core, the module still registers the status but
+every status name renders **blank** in the UI and audit trail. When merging
+upstream FreeScout releases into the fork, verify both patches survived.
+
+## Activation
+
+Manage → Modules → OnHoldStatus → Activate (or `php artisan freescout:module-install onholdstatus`
+equivalent flow). Activation state lives in the **database** — the `active`
+flag in `module.json` is ignored (see `app/Module.php`). No migrations, no
+licence.
+
+## Deactivation caveat
+
+Deactivating with status-5 conversations still in the database does **not**
+crash anything — `Conversation::getStatus()` falls back to Active for
+unregistered codes, so views render — but those conversations show an Active-
+styled button with a blank status name, and stop appearing in any On-Hold
+view. Before deactivating in production, remap the data first:
+
+```sql
+UPDATE conversations SET status = 2 WHERE status = 5; -- On-Hold → Pending
+```
+
+(Historical thread rows with status 5 can stay — they only affect how old
+audit-trail lines render.)
+
+## Reporting
+
+The reason this exists instead of an `on-hold` tag: status changes are logged
+as typed thread events. Entering On-Hold creates a `Thread` line item
+(`ACTION_TYPE_STATUS_CHANGED`, status 5, timestamped); leaving it creates
+either another line item (agent action) or a timestamped customer-reply thread
+(which flips the conversation back to Active — `FetchEmails.php` treats
+status 5 like Pending). Time-in-On-Hold is therefore derivable from the
+`threads` table from day one. Whether the paid Reports module *displays*
+an On-Hold slice needs on-instance verification (see ARMS-12's
+post-activation checklist); the fallback is custom queries on `threads`.
+
+## Tests
+
+`tests/Unit/OnHoldStatusTest.php` — covers the filter fallback, registration
+on both models, non-regression of existing statuses, and the `getStatus()`
+deactivation guard. Note: the repo's pinned phpunit (9.5.28) cannot run on
+PHP 8.5 (its error handler fatals on its own deprecations); the same
+assertions pass via a plain boot script until the harness is upgraded.

--- a/Modules/OnHoldStatus/module.json
+++ b/Modules/OnHoldStatus/module.json
@@ -1,0 +1,22 @@
+{
+    "name": "OnHoldStatus",
+    "alias": "onholdstatus",
+    "description": "Adds On-Hold as a first-class conversation status (ARMS-12). Registers status code 5 with core via the conversation.status_name filter carried on the threls fork.",
+    "version": "1.0.0",
+    "detailsUrl": "",
+    "author": "Threls",
+    "authorUrl": "https://threls.com",
+    "requiredAppVersion": "1.8.0",
+    "license": "AGPL-3.0",
+    "keywords": ["status", "on-hold"],
+    "active": 0,
+    "order": 0,
+    "providers": [
+        "Modules\\OnHoldStatus\\Providers\\OnHoldStatusServiceProvider"
+    ],
+    "aliases": {},
+    "files": [
+        "start.php"
+    ],
+    "requires": []
+}

--- a/Modules/OnHoldStatus/start.php
+++ b/Modules/OnHoldStatus/start.php
@@ -1,0 +1,11 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| OnHoldStatus module bootstrap
+|--------------------------------------------------------------------------
+|
+| This module has no routes or views — all registration happens in the
+| service provider (Providers/OnHoldStatusServiceProvider.php).
+|
+*/

--- a/app/Conversation.php
+++ b/app/Conversation.php
@@ -586,7 +586,8 @@ class Conversation extends Model
             //     break;
 
             default:
-                return '';
+                // Allows modules to register extra statuses (threls fork patch, ARMS-12).
+                return \Eventy::filter('conversation.status_name', '', $status);
                 break;
         }
     }

--- a/app/Thread.php
+++ b/app/Thread.php
@@ -527,7 +527,9 @@ class Thread extends Model
                 break;
 
             default:
-                return '';
+                // Allows modules to register extra statuses (threls fork patch, ARMS-12).
+                // Status codes are shared with conversations, so the same filter serves both.
+                return \Eventy::filter('conversation.status_name', '', $status);
                 break;
         }
     }

--- a/tests/Unit/OnHoldStatusTest.php
+++ b/tests/Unit/OnHoldStatusTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Conversation;
+use App\Thread;
+use Tests\TestCase;
+
+/**
+ * Covers the OnHoldStatus module (ARMS-12) and the two fork patches it
+ * depends on: the conversation.status_name Eventy filter in the default
+ * case of Conversation::statusCodeToName() and Thread::statusCodeToName().
+ */
+class OnHoldStatusTest extends TestCase
+{
+    const ONHOLD = 5;
+
+    protected $statuses_backup = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The module is not autoloaded while inactive — load the provider directly.
+        require_once __DIR__.'/../../Modules/OnHoldStatus/Providers/OnHoldStatusServiceProvider.php';
+
+        // Static arrays persist across tests in the same process — back them up.
+        $this->statuses_backup = [
+            'statuses'        => Conversation::$statuses,
+            'status_icons'    => Conversation::$status_icons,
+            'status_classes'  => Conversation::$status_classes,
+            'status_colors'   => Conversation::$status_colors,
+            'thread_statuses' => Thread::$statuses,
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        Conversation::$statuses = $this->statuses_backup['statuses'];
+        Conversation::$status_icons = $this->statuses_backup['status_icons'];
+        Conversation::$status_classes = $this->statuses_backup['status_classes'];
+        Conversation::$status_colors = $this->statuses_backup['status_colors'];
+        Thread::$statuses = $this->statuses_backup['thread_statuses'];
+
+        parent::tearDown();
+    }
+
+    protected function bootModule()
+    {
+        (new \Modules\OnHoldStatus\Providers\OnHoldStatusServiceProvider(app()))->boot();
+    }
+
+    /**
+     * Without the module, the fork patch must preserve core behaviour:
+     * unknown status codes render as an empty string.
+     * (The Eventy singleton is rebuilt per test, so no filter is registered here.)
+     */
+    public function test_unknown_status_renders_empty_without_module()
+    {
+        $this->assertSame('', Conversation::statusCodeToName(self::ONHOLD));
+        $this->assertSame('', Thread::statusCodeToName(self::ONHOLD));
+    }
+
+    public function test_module_registers_on_hold_status()
+    {
+        $this->bootModule();
+
+        // Name resolution through the fork-patch filter, on both models.
+        $this->assertSame('On Hold', Conversation::statusCodeToName(self::ONHOLD));
+        $this->assertSame('On Hold', Thread::statusCodeToName(self::ONHOLD));
+
+        // All four Conversation registries + the Thread registry get the status,
+        // so Blade's direct array indexing cannot hit an undefined key.
+        $this->assertArrayHasKey(self::ONHOLD, Conversation::$statuses);
+        $this->assertArrayHasKey(self::ONHOLD, Conversation::$status_icons);
+        $this->assertArrayHasKey(self::ONHOLD, Conversation::$status_classes);
+        $this->assertArrayHasKey(self::ONHOLD, Conversation::$status_colors);
+        $this->assertArrayHasKey(self::ONHOLD, Thread::$statuses);
+
+        // Status-change validation (Conversation::changeStatus) accepts it.
+        $this->assertTrue(array_key_exists(self::ONHOLD, Conversation::$statuses));
+    }
+
+    public function test_existing_statuses_are_unaffected()
+    {
+        $this->bootModule();
+
+        $this->assertSame('Pending', Conversation::statusCodeToName(Conversation::STATUS_PENDING));
+        $this->assertSame('Active', Conversation::statusCodeToName(Conversation::STATUS_ACTIVE));
+        $this->assertSame('Not changed', Thread::statusCodeToName(Thread::STATUS_NOCHANGE));
+
+        // Truly unknown codes still render empty even with the module active.
+        $this->assertSame('', Conversation::statusCodeToName(99));
+    }
+
+    /**
+     * If the module is ever deactivated while status-5 rows exist,
+     * getStatus() must fall back gracefully (core guard, Conversation.php:623)
+     * so Blade's $status_classes[getStatus()] indexing cannot crash.
+     */
+    public function test_get_status_falls_back_for_unregistered_codes()
+    {
+        $conversation = new Conversation();
+        $conversation->status = self::ONHOLD;
+
+        $this->assertSame(Conversation::STATUS_ACTIVE, $conversation->getStatus());
+
+        $this->bootModule();
+
+        $this->assertSame(self::ONHOLD, $conversation->getStatus());
+    }
+}


### PR DESCRIPTION
ARMS's ticket lifecycle requires an On-Hold status; FreeScout hard-codes four. This adds status code 5 via a small custom module plus two fork patches, keeping the upstream-merge surface minimal.

- Modules/OnHoldStatus: appends status 5 (name/icon/class/color) to the mutable static registries on Conversation and Thread at boot, and resolves the name through a new conversation.status_name Eventy filter
- Fork patches: the default cases of Conversation::statusCodeToName() and Thread::statusCodeToName() now consult that filter instead of returning '' (Thread's switch also renders the audit-trail line, so both are required)
- .gitignore: /Modules -> /Modules/* with !/Modules/OnHoldStatus so custom modules are version-controlled while runtime-installed paid modules stay ignored
- tests/Unit/OnHoldStatusTest.php: filter fallback, registration on both models, non-regression of core statuses, getStatus() deactivation guard (note: pinned phpunit 9.5.28 cannot run under PHP 8.5; the same assertions pass via a plain boot script)

Verified against core call sites: validation (array_key_exists on the registry), changeStatus() audit thread, updateFolder() fallthrough, folder counters, customer-reply reopen in FetchEmails, data-driven JS.

Keep in mind that pull requests should be sent to the `master` branch! See https://github.com/freescout-helpdesk/freescout/wiki/Development-Guide#github-workflow

Now you can delete this text and type the description of your pull request...