### PR TITLE
Stop the test environment from emailing real customers (ARMS-16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Thumbs.db
 /Modules/**/.git
 # Threls custom modules are version-controlled (paid modules above stay runtime-installed)
 !/Modules/OnHoldStatus
+!/Modules/TestEmailGuard
 /public/modules
 /public/docs
 /public/.dh-diag

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,10 @@ Thumbs.db
 /public/css/builds/
 /public/js/builds/
 /public/.well-known
-/Modules
+/Modules/*
 /Modules/**/.git
+# Threls custom modules are version-controlled (paid modules above stay runtime-installed)
+!/Modules/OnHoldStatus
 /public/modules
 /public/docs
 /public/.dh-diag

--- a/Modules/OnHoldStatus/Providers/OnHoldStatusServiceProvider.php
+++ b/Modules/OnHoldStatus/Providers/OnHoldStatusServiceProvider.php
@@ -47,17 +47,45 @@ class OnHoldStatusServiceProvider extends ServiceProvider
 
     /**
      * Register the On-Hold status with core's status registries.
+     *
+     * Inserted after Pending (not appended) so every surface that iterates
+     * the registries — status dropdown, search filter, bulk actions, the
+     * Custom Folders checkboxes — renders the lifecycle order
+     * Active, Pending, On Hold, Closed, Spam (ARMS-14).
      */
     protected function registerStatus()
     {
-        Conversation::$statuses[self::STATUS_ONHOLD] = 'onhold';
-        Conversation::$status_icons[self::STATUS_ONHOLD] = 'pause';
-        Conversation::$status_classes[self::STATUS_ONHOLD] = 'warning';
-        Conversation::$status_colors[self::STATUS_ONHOLD] = '#f39c12';
+        Conversation::$statuses = self::insertAfter(Conversation::$statuses, Conversation::STATUS_PENDING, self::STATUS_ONHOLD, 'onhold');
+        Conversation::$status_icons = self::insertAfter(Conversation::$status_icons, Conversation::STATUS_PENDING, self::STATUS_ONHOLD, 'pause');
+        Conversation::$status_classes = self::insertAfter(Conversation::$status_classes, Conversation::STATUS_PENDING, self::STATUS_ONHOLD, 'warning');
+        Conversation::$status_colors = self::insertAfter(Conversation::$status_colors, Conversation::STATUS_PENDING, self::STATUS_ONHOLD, '#f39c12');
 
         // Status codes must match between conversations and threads
         // (see the comment above Conversation's status constants).
-        Thread::$statuses[self::STATUS_ONHOLD] = 'onhold';
+        Thread::$statuses = self::insertAfter(Thread::$statuses, Thread::STATUS_PENDING, self::STATUS_ONHOLD, 'onhold');
+    }
+
+    /**
+     * Insert $value under $new_key immediately after $after_key, preserving
+     * the order of everything else. Appends if $after_key is absent.
+     */
+    protected static function insertAfter(array $array, $after_key, $new_key, $value)
+    {
+        $result = [];
+        foreach ($array as $key => $existing) {
+            if ($key === $new_key) {
+                continue; // idempotency: drop a pre-existing entry, re-insert in position
+            }
+            $result[$key] = $existing;
+            if ($key === $after_key) {
+                $result[$new_key] = $value;
+            }
+        }
+        if (!array_key_exists($new_key, $result)) {
+            $result[$new_key] = $value;
+        }
+
+        return $result;
     }
 
     /**

--- a/Modules/OnHoldStatus/Providers/OnHoldStatusServiceProvider.php
+++ b/Modules/OnHoldStatus/Providers/OnHoldStatusServiceProvider.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Modules\OnHoldStatus\Providers;
+
+use App\Conversation;
+use App\Thread;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Adds On-Hold as a first-class conversation status (ARMS-12).
+ *
+ * Core hard-codes four statuses (Active/Pending/Closed/Spam) but exposes them
+ * as mutable static arrays that Blade dropdowns, validation and JS all read
+ * from — so appending a fifth status here propagates everywhere except
+ * statusCodeToName(), which is covered by the conversation.status_name
+ * filter added to core on the threls fork (see ARMS-12).
+ *
+ * Status mapping for ARMS needs only this one new status:
+ * New = Active+unassigned · Open = Active+assigned · Pending = Pending ·
+ * On-Hold = 5 (this module) · Solved = Closed.
+ */
+class OnHoldStatusServiceProvider extends ServiceProvider
+{
+    /**
+     * Status code 5 is free on both models: Conversation reserves it as a
+     * commented-out STATUS_OPEN, and Thread::STATUS_NOCHANGE already took 6.
+     */
+    const STATUS_ONHOLD = 5;
+
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = false;
+
+    /**
+     * Boot the application events.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->registerStatus();
+        $this->hooks();
+    }
+
+    /**
+     * Register the On-Hold status with core's status registries.
+     */
+    protected function registerStatus()
+    {
+        Conversation::$statuses[self::STATUS_ONHOLD] = 'onhold';
+        Conversation::$status_icons[self::STATUS_ONHOLD] = 'pause';
+        Conversation::$status_classes[self::STATUS_ONHOLD] = 'warning';
+        Conversation::$status_colors[self::STATUS_ONHOLD] = '#f39c12';
+
+        // Status codes must match between conversations and threads
+        // (see the comment above Conversation's status constants).
+        Thread::$statuses[self::STATUS_ONHOLD] = 'onhold';
+    }
+
+    /**
+     * Module hooks.
+     */
+    public function hooks()
+    {
+        // Resolves the status name for both Conversation::statusCodeToName()
+        // and Thread::statusCodeToName() (fork patch, ARMS-12).
+        \Eventy::addFilter('conversation.status_name', function ($name, $status) {
+            if ((int) $status === self::STATUS_ONHOLD) {
+                return __('On Hold');
+            }
+
+            return $name;
+        }, 20, 2);
+    }
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+    }
+}

--- a/Modules/OnHoldStatus/Providers/OnHoldStatusServiceProvider.php
+++ b/Modules/OnHoldStatus/Providers/OnHoldStatusServiceProvider.php
@@ -74,6 +74,15 @@ class OnHoldStatusServiceProvider extends ServiceProvider
 
             return $name;
         }, 20, 2);
+
+        // The Mine folder and chat list are live queries with an "open statuses"
+        // whitelist (Active/Pending) rather than real folders — without this,
+        // On-Hold conversations vanish from Mine (fork patch, ARMS-12).
+        \Eventy::addFilter('conversation.open_statuses', function ($statuses) {
+            $statuses[] = self::STATUS_ONHOLD;
+
+            return $statuses;
+        });
     }
 
     /**

--- a/Modules/OnHoldStatus/Providers/OnHoldStatusServiceProvider.php
+++ b/Modules/OnHoldStatus/Providers/OnHoldStatusServiceProvider.php
@@ -79,6 +79,7 @@ class OnHoldStatusServiceProvider extends ServiceProvider
         // whitelist (Active/Pending) rather than real folders — without this,
         // On-Hold conversations vanish from Mine (fork patch, ARMS-12).
         \Eventy::addFilter('conversation.open_statuses', function ($statuses) {
+            $statuses = (array) $statuses;
             $statuses[] = self::STATUS_ONHOLD;
 
             return $statuses;

--- a/Modules/OnHoldStatus/README.md
+++ b/Modules/OnHoldStatus/README.md
@@ -1,0 +1,72 @@
+# OnHoldStatus
+
+Adds **On-Hold** as a first-class conversation status (code `5`) for ARMS.
+Tracked as [ARMS-12](https://threls.atlassian.net/browse/ARMS-12).
+
+ARMS's status lifecycle is New/Open/Pending/**On-Hold**/Solved. Core FreeScout
+hard-codes four statuses; only On-Hold needs adding — the rest map natively
+(New = Active+unassigned, Open = Active+assigned, Solved = Closed).
+
+## How it works
+
+The service provider appends status 5 to core's mutable static registries at
+boot — `Conversation::$statuses` / `$status_icons` / `$status_classes` /
+`$status_colors` and `Thread::$statuses`. Status dropdowns (conversation view,
+search filters, bulk actions), validation, folder logic, and counters all read
+those arrays, so the status propagates with no further wiring.
+
+The status *name* resolves through the `conversation.status_name` Eventy
+filter, which this module answers with "On Hold".
+
+## ⚠ Depends on two fork patches — will not work on stock FreeScout
+
+`Conversation::statusCodeToName()` and `Thread::statusCodeToName()` are
+hardcoded switches in core. The threls fork patches their `default:` cases to
+call the `conversation.status_name` filter (see ARMS-12; grep for
+`threls fork patch` in `app/Conversation.php` / `app/Thread.php`).
+
+Installed on an unpatched core, the module still registers the status but
+every status name renders **blank** in the UI and audit trail. When merging
+upstream FreeScout releases into the fork, verify both patches survived.
+
+## Activation
+
+Manage → Modules → OnHoldStatus → Activate (or `php artisan freescout:module-install onholdstatus`
+equivalent flow). Activation state lives in the **database** — the `active`
+flag in `module.json` is ignored (see `app/Module.php`). No migrations, no
+licence.
+
+## Deactivation caveat
+
+Deactivating with status-5 conversations still in the database does **not**
+crash anything — `Conversation::getStatus()` falls back to Active for
+unregistered codes, so views render — but those conversations show an Active-
+styled button with a blank status name, and stop appearing in any On-Hold
+view. Before deactivating in production, remap the data first:
+
+```sql
+UPDATE conversations SET status = 2 WHERE status = 5; -- On-Hold → Pending
+```
+
+(Historical thread rows with status 5 can stay — they only affect how old
+audit-trail lines render.)
+
+## Reporting
+
+The reason this exists instead of an `on-hold` tag: status changes are logged
+as typed thread events. Entering On-Hold creates a `Thread` line item
+(`ACTION_TYPE_STATUS_CHANGED`, status 5, timestamped); leaving it creates
+either another line item (agent action) or a timestamped customer-reply thread
+(which flips the conversation back to Active — `FetchEmails.php` treats
+status 5 like Pending). Time-in-On-Hold is therefore derivable from the
+`threads` table from day one. Whether the paid Reports module *displays*
+an On-Hold slice needs on-instance verification (see ARMS-12's
+post-activation checklist); the fallback is custom queries on `threads`.
+
+## Tests
+
+`tests/Unit/OnHoldStatusTest.php` — covers the filter fallback, registration
+on both models, non-regression of existing statuses, and the `getStatus()`
+deactivation guard. Note: the repo's pinned phpunit (9.5.28) cannot run on
+PHP 8.5 (its error handler fatals on its own deprecations); the same
+assertions pass via a plain boot script until the harness is upgraded.

--- a/Modules/OnHoldStatus/README.md
+++ b/Modules/OnHoldStatus/README.md
@@ -18,16 +18,23 @@ those arrays, so the status propagates with no further wiring.
 The status *name* resolves through the `conversation.status_name` Eventy
 filter, which this module answers with "On Hold".
 
-## ⚠ Depends on two fork patches — will not work on stock FreeScout
+## ⚠ Depends on fork patches — will not work on stock FreeScout
 
-`Conversation::statusCodeToName()` and `Thread::statusCodeToName()` are
-hardcoded switches in core. The threls fork patches their `default:` cases to
-call the `conversation.status_name` filter (see ARMS-12; grep for
-`threls fork patch` in `app/Conversation.php` / `app/Thread.php`).
+Two filters were added to core on the threls fork (grep for
+`threls fork patch` in `app/Conversation.php` / `app/Thread.php`):
 
-Installed on an unpatched core, the module still registers the status but
-every status name renders **blank** in the UI and audit trail. When merging
-upstream FreeScout releases into the fork, verify both patches survived.
+1. **`conversation.status_name`** — the `default:` cases of
+   `Conversation::statusCodeToName()` and `Thread::statusCodeToName()` are
+   hardcoded switches; without this patch every On-Hold status name renders
+   **blank** in the UI and audit trail.
+2. **`conversation.open_statuses`** — the Mine folder and chat list are
+   live queries with a hardcoded `status IN (Active, Pending)` whitelist
+   (`Conversation::getQueryByFolder()` and `Conversation::getChats()`);
+   without this patch, On-Hold conversations **vanish from the Mine folder**
+   (found live on the demo instance, 13 Jul).
+
+When merging upstream FreeScout releases into the fork, verify all four
+patched call sites survived.
 
 ## Activation
 

--- a/Modules/OnHoldStatus/module.json
+++ b/Modules/OnHoldStatus/module.json
@@ -1,0 +1,22 @@
+{
+    "name": "OnHoldStatus",
+    "alias": "onholdstatus",
+    "description": "Adds On-Hold as a first-class conversation status (ARMS-12). Registers status code 5 with core via the conversation.status_name filter carried on the threls fork.",
+    "version": "1.0.0",
+    "detailsUrl": "",
+    "author": "Threls",
+    "authorUrl": "https://threls.com",
+    "requiredAppVersion": "1.8.0",
+    "license": "AGPL-3.0",
+    "keywords": ["status", "on-hold"],
+    "active": 0,
+    "order": 0,
+    "providers": [
+        "Modules\\OnHoldStatus\\Providers\\OnHoldStatusServiceProvider"
+    ],
+    "aliases": {},
+    "files": [
+        "start.php"
+    ],
+    "requires": []
+}

--- a/Modules/OnHoldStatus/start.php
+++ b/Modules/OnHoldStatus/start.php
@@ -1,0 +1,11 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| OnHoldStatus module bootstrap
+|--------------------------------------------------------------------------
+|
+| This module has no routes or views — all registration happens in the
+| service provider (Providers/OnHoldStatusServiceProvider.php).
+|
+*/

--- a/Modules/TestEmailGuard/Console/AnonymizeStoredEmails.php
+++ b/Modules/TestEmailGuard/Console/AnonymizeStoredEmails.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Modules\TestEmailGuard\Console;
+
+use Illuminate\Console\Command;
+use Modules\TestEmailGuard\Services\EmailAnonymizer;
+
+/**
+ * Anonymises customer email addresses stored in the database (ARMS-16).
+ *
+ * Intended to run in the test environment right after real customer data
+ * lands there — e.g. after a Zendesk demo migration — so the database
+ * carries no real addresses. The transform is idempotent, so re-running
+ * the command is safe.
+ *
+ * Covered: emails.email, conversations.customer_email, threads.from and
+ * the threads to/cc/bcc recipient lists. Deliberately not covered: the
+ * users table (agents are staff, not customers) and free text inside
+ * email bodies — the outbound guard is the protection there, as text in
+ * a body cannot cause a send.
+ */
+class AnonymizeStoredEmails extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'test-email-guard:anonymize-stored {--force : Skip the confirmation prompt}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Anonymise stored customer email addresses (test environments only)';
+
+    const CHUNK = 500;
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        if (config('app.env') === 'production') {
+            $this->error('This command is destructive and refuses to run in production.');
+
+            return 1;
+        }
+
+        if (!$this->option('force')
+            && !$this->confirm('Irreversibly anonymise all non-allow-listed customer email addresses in this database?')
+        ) {
+            return 1;
+        }
+
+        $this->line('Allow-listed domains (left untouched): '.implode(', ', EmailAnonymizer::allowedDomains()));
+
+        $this->anonymizeEmails();
+        $this->anonymizeConversations();
+        $this->anonymizeThreads();
+
+        $this->info('Done. Re-running this command is safe (the transform is idempotent).');
+
+        return 0;
+    }
+
+    protected function anonymizeEmails()
+    {
+        $updated = 0;
+
+        \DB::table('emails')->select('id', 'email')->orderBy('id')->chunkById(self::CHUNK, function ($rows) use (&$updated) {
+            foreach ($rows as $row) {
+                $anonymized = EmailAnonymizer::anonymize($row->email);
+                if ($anonymized !== $row->email) {
+                    \DB::table('emails')->where('id', $row->id)->update(['email' => $anonymized]);
+                    $updated++;
+                }
+            }
+        });
+
+        $this->line('emails.email: '.$updated.' updated');
+    }
+
+    protected function anonymizeConversations()
+    {
+        $updated = 0;
+
+        \DB::table('conversations')->select('id', 'customer_email')->orderBy('id')->chunkById(self::CHUNK, function ($rows) use (&$updated) {
+            foreach ($rows as $row) {
+                if (!$row->customer_email) {
+                    continue;
+                }
+                $anonymized = EmailAnonymizer::anonymize($row->customer_email);
+                if ($anonymized !== $row->customer_email) {
+                    \DB::table('conversations')->where('id', $row->id)->update(['customer_email' => $anonymized]);
+                    $updated++;
+                }
+            }
+        });
+
+        $this->line('conversations.customer_email: '.$updated.' updated');
+    }
+
+    protected function anonymizeThreads()
+    {
+        $updated = 0;
+
+        \DB::table('threads')->select('id', 'from', 'to', 'cc', 'bcc')->orderBy('id')->chunkById(self::CHUNK, function ($rows) use (&$updated) {
+            foreach ($rows as $row) {
+                $changes = [];
+
+                if ($row->from) {
+                    $anonymized = EmailAnonymizer::anonymize($row->from);
+                    if ($anonymized !== $row->from) {
+                        $changes['from'] = $anonymized;
+                    }
+                }
+
+                foreach (['to', 'cc', 'bcc'] as $field) {
+                    if (!$row->$field) {
+                        continue;
+                    }
+                    $emails = \App\Misc\Helper::jsonToArray($row->$field);
+                    if (!$emails) {
+                        continue;
+                    }
+                    $anonymized_list = array_values(array_unique(array_map(function ($email) {
+                        return EmailAnonymizer::anonymize($email);
+                    }, $emails)));
+                    if ($anonymized_list !== array_values($emails)) {
+                        $changes[$field] = \App\Misc\Helper::jsonEncodeUtf8($anonymized_list);
+                    }
+                }
+
+                if ($changes) {
+                    \DB::table('threads')->where('id', $row->id)->update($changes);
+                    $updated++;
+                }
+            }
+        });
+
+        $this->line('threads (from/to/cc/bcc): '.$updated.' updated');
+    }
+}

--- a/Modules/TestEmailGuard/Console/GuardStatus.php
+++ b/Modules/TestEmailGuard/Console/GuardStatus.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Modules\TestEmailGuard\Console;
+
+use Illuminate\Console\Command;
+use Modules\TestEmailGuard\Providers\TestEmailGuardServiceProvider;
+use Modules\TestEmailGuard\Services\EmailAnonymizer;
+
+/**
+ * Prints the effective state of the outbound email guard (ARMS-16), so the
+ * environment can be verified before handing it over for bulk testing.
+ */
+class GuardStatus extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'test-email-guard:status';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Show whether the outbound email guard is active and how it is configured';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $env = config('app.env');
+        $active = TestEmailGuardServiceProvider::guardActive();
+        $sink = EmailAnonymizer::sink();
+
+        $this->line('app.env: '.$env);
+        $this->line('Allow-listed domains: '.implode(', ', EmailAnonymizer::allowedDomains()));
+        $this->line('Rewrite target: '.($sink ? 'sink mailbox '.$sink.' (plus-addressed, mail delivers)' : EmailAnonymizer::SAFE_DOMAIN.' (mail will bounce)'));
+        $this->line('Sample: customer@gmail.com → '.EmailAnonymizer::rewriteRecipient('customer@gmail.com'));
+
+        if ($active) {
+            $this->info('GUARD ACTIVE (while this module is activated) — non-allow-listed outbound recipients are rewritten.');
+        } else {
+            $this->error('GUARD DISABLED — app.env is "production", so outbound email flows normally. If this is a test/demo instance, set APP_ENV (e.g. "demo") in .env.');
+        }
+
+        // Note: this command reports config, not module activation — if the
+        // module is deactivated in Modules, nothing is rewritten regardless.
+        $this->line('Reminder: the guard only runs while the TestEmailGuard module is Active under Manage → Modules.');
+
+        return $active ? 0 : 1;
+    }
+}

--- a/Modules/TestEmailGuard/Providers/TestEmailGuardServiceProvider.php
+++ b/Modules/TestEmailGuard/Providers/TestEmailGuardServiceProvider.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Modules\TestEmailGuard\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Modules\TestEmailGuard\Services\EmailAnonymizer;
+
+/**
+ * Test-environment outbound email guard (ARMS-16).
+ *
+ * Core fires the mail.process_swift_message Eventy filter for every outbound
+ * message via the Illuminate MessageSending event (EventServiceProvider →
+ * ProcessSwiftMessage listener), regardless of which Mailable built it —
+ * customer replies, auto-replies, workflow emails, user notifications,
+ * alerts. Hooking that single filter therefore guards every send path
+ * without touching core, and unlike a Swift Mailer plugin it survives
+ * core's per-mailbox rebuilding of the swift.mailer instance.
+ *
+ * Safety model:
+ *  - Enabling = activating the module. There is no "on" flag that can be
+ *    forgotten — if the module is active outside production, the guard runs.
+ *  - Hard environment gate: when app.env is production the guard refuses to
+ *    rewrite anything, even if the module is activated there by mistake.
+ */
+class TestEmailGuardServiceProvider extends ServiceProvider
+{
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = false;
+
+    /**
+     * Boot the application events.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        // Fail loudly, not silently: an operator who activates this module
+        // believing it protects the environment must find out that the
+        // production gate has switched it off (Forge-style deploys default
+        // to APP_ENV=production — test/demo instances must override it).
+        if (!self::guardActive()) {
+            \Log::error('TestEmailGuard is activated but disabled: app.env is "production". Outbound email is NOT being rewritten. Set APP_ENV (e.g. to "demo") in this environment\'s .env if this is not a real production instance.');
+        }
+
+        $this->hooks();
+    }
+
+    /**
+     * Module hooks.
+     */
+    public function hooks()
+    {
+        \Eventy::addFilter('mail.process_swift_message', function ($proceed, $message) {
+            if (!$proceed || !self::guardActive()) {
+                return $proceed;
+            }
+
+            self::rewriteMessageRecipients($message);
+
+            return $proceed;
+        }, 20, 2);
+    }
+
+    /**
+     * The guard must never rewrite (or be relied upon) in production.
+     */
+    public static function guardActive()
+    {
+        return config('app.env') !== 'production';
+    }
+
+    /**
+     * Rewrite non-allow-listed To/Cc/Bcc addresses on the outgoing
+     * Swift_Message, preserving display names.
+     */
+    public static function rewriteMessageRecipients($message)
+    {
+        foreach (['To', 'Cc', 'Bcc'] as $field) {
+            $getter = 'get'.$field;
+            $setter = 'set'.$field;
+
+            $recipients = $message->$getter();
+            if (!$recipients) {
+                continue;
+            }
+
+            $rewritten = [];
+            $changed = false;
+            foreach ($recipients as $email => $name) {
+                $target = EmailAnonymizer::isAllowed($email)
+                    ? $email
+                    : EmailAnonymizer::rewriteRecipient($email);
+
+                if ($target !== $email) {
+                    $changed = true;
+                }
+                $rewritten[$target] = $name;
+            }
+
+            if ($changed) {
+                $message->$setter($rewritten);
+            }
+        }
+    }
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->commands([
+            \Modules\TestEmailGuard\Console\AnonymizeStoredEmails::class,
+            \Modules\TestEmailGuard\Console\GuardStatus::class,
+        ]);
+    }
+}

--- a/Modules/TestEmailGuard/README.md
+++ b/Modules/TestEmailGuard/README.md
@@ -1,0 +1,53 @@
+# TestEmailGuard
+
+Test-environment email safety net ([ARMS-16](https://threls.atlassian.net/browse/ARMS-16)). Lets the team bulk-test with realistic customer data while making it impossible for the test instance to email real people.
+
+Two layers, belt and braces:
+
+1. **Send-time guard** — every outbound recipient (To/Cc/Bcc, on every send path: replies, auto-replies, workflow emails, notifications, alerts) is rewritten to a safe address unless its domain is allow-listed.
+2. **Stored-data anonymisation** — a console command rewrites customer addresses already in the database (run it right after importing real data, e.g. a Zendesk demo migration), so the DB carries no real addresses in the first place.
+
+## The transform
+
+The original domain is folded into the local part so distinct customers stay distinct:
+
+```
+tanti.omar@gmail.com  →  tanti.omar+gmail.com@example.com
+```
+
+A flat "replace the domain" would merge `john@gmail.com` and `john@yahoo.com` into one customer record. `example.com` is IANA-reserved, so anonymised addresses can never deliver. If `local+domain` would exceed the 64-character local-part limit, it falls back to `local…+<10-char-hash>` (uniqueness kept; reversibility knowingly dropped). Everything is lowercased. The transform is idempotent — re-running it is safe.
+
+## Enabling
+
+Activation **is** the switch: activate the module (Manage → Modules) in the environment that must be guarded. There is no "enable" flag that can be forgotten.
+
+**Hard production block:** when `app.env` is `production` the guard refuses to rewrite anything, even if the module is activated there by mistake (it logs an error so the mismatch is visible). ⚠ Forge-style deploys default to `APP_ENV=production` — on a test/demo instance you **must** set e.g. `APP_ENV=demo` in `.env`, or the guard stays off and mail flows normally. Verify with:
+
+```
+php artisan test-email-guard:status
+```
+
+which prints the effective state and a sample rewrite, and exits non-zero if the guard is disabled.
+
+## Configuration (`.env`, all optional)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `TEST_EMAIL_GUARD_ALLOW_DOMAINS` | `arms.com.mt,threls.com` | Comma-separated domains whose recipients receive real mail, untouched. Exact-domain match (subdomains and lookalike suffixes are rewritten). |
+| `TEST_EMAIL_GUARD_SINK` | *(empty)* | A real mailbox to plus-address rewritten mail into, e.g. `armssink@threls.onmicrosoft.com` → mail arrives as `armssink+tanti.omar+gmail.com@…` and can be inspected. When empty, rewrites target `example.com` and sends will bounce (NDR noise in the helpdesk — a sink is recommended for bulk testing). |
+
+On the demo instance also consider allow-listing `threls.onmicrosoft.com` (the demo mailboxes' own domain) so inter-mailbox test flows deliver.
+
+## Anonymising stored data
+
+```
+php artisan test-email-guard:anonymize-stored
+```
+
+Rewrites `emails.email`, `conversations.customer_email` and the `threads` from/to/cc/bcc fields. Refuses to run when `app.env` is `production`; prompts for confirmation unless `--force` is given. Agents (`users` table) are deliberately untouched. Addresses inside message body text are not rewritten — text in a body cannot cause a send; the outbound guard is the protection there.
+
+**Runbook for a migration test:** import → `test-email-guard:anonymize-stored` → `test-email-guard:status` → hand over for testing.
+
+## How the guard hooks in
+
+Core fires the `mail.process_swift_message` Eventy filter (via Laravel's `MessageSending` event → `App\Listeners\ProcessSwiftMessage`) for every outgoing message immediately before transport, regardless of which Mailable built it. The module hooks that single filter — no core patch needed, and unlike a registered Swift Mailer plugin it survives core's per-mailbox rebuilding of the mailer instance.

--- a/Modules/TestEmailGuard/Services/EmailAnonymizer.php
+++ b/Modules/TestEmailGuard/Services/EmailAnonymizer.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Modules\TestEmailGuard\Services;
+
+/**
+ * Anonymises email addresses for the test environment (ARMS-16).
+ *
+ * The transform folds the original domain into the local part so that
+ * distinct addresses stay distinct after anonymisation:
+ *
+ *     tanti.omar@gmail.com  →  tanti.omar+gmail.com@example.com
+ *
+ * A flat "replace the domain" would merge john@gmail.com and john@yahoo.com
+ * into one customer record; folding keeps the mapping unique. example.com is
+ * IANA-reserved (RFC 2606) so an anonymised address can never deliver.
+ *
+ * Two output modes:
+ *  - anonymize()         → local+domain@example.com — for data at rest
+ *                          (seeded/imported customer records).
+ *  - rewriteRecipient()  → send-time target. Same as anonymize() unless a
+ *                          sink mailbox is configured (TEST_EMAIL_GUARD_SINK),
+ *                          in which case recipients are plus-addressed into
+ *                          the sink so mail really delivers somewhere
+ *                          inspectable instead of bouncing:
+ *                          armssink+tanti.omar+gmail.com@threls.onmicrosoft.com
+ */
+class EmailAnonymizer
+{
+    const SAFE_DOMAIN = 'example.com';
+
+    /**
+     * RFC 5321 limit for the local part of an address.
+     */
+    const LOCAL_PART_MAX = 64;
+
+    const HASH_LENGTH = 10;
+
+    /**
+     * Domains whose recipients receive real mail, untouched.
+     * Comparison is by exact domain, not suffix — mail to a lookalike
+     * subdomain must not slip through the guard.
+     */
+    public static function allowedDomains()
+    {
+        $env = env('TEST_EMAIL_GUARD_ALLOW_DOMAINS');
+
+        $domains = $env ? explode(',', $env) : ['arms.com.mt', 'threls.com'];
+
+        return array_values(array_filter(array_map(function ($domain) {
+            return strtolower(trim($domain));
+        }, $domains)));
+    }
+
+    /**
+     * Optional sink mailbox for send-time rewrites (a real mailbox the
+     * team controls). Empty/invalid → example.com mode (sends will bounce).
+     */
+    public static function sink()
+    {
+        $sink = env('TEST_EMAIL_GUARD_SINK');
+
+        if (!$sink || strpos($sink, '@') === false) {
+            return null;
+        }
+
+        return strtolower(trim($sink));
+    }
+
+    public static function isAllowed($email)
+    {
+        $domain = self::domainOf($email);
+
+        return $domain !== null && in_array($domain, self::allowedDomains());
+    }
+
+    /**
+     * Anonymise an address for storage: local+domain@example.com.
+     * Allow-listed and already-anonymised addresses pass through unchanged,
+     * so the transform is idempotent and safe to re-run.
+     */
+    public static function anonymize($email)
+    {
+        $email = mb_strtolower(trim($email ?? ''), 'UTF-8');
+        $domain = self::domainOf($email);
+
+        if ($domain === null || $domain === self::SAFE_DOMAIN || self::isAllowed($email)) {
+            return $email;
+        }
+
+        $local = substr($email, 0, strrpos($email, '@'));
+
+        return self::capLocal($local.'+'.$domain, $email).'@'.self::SAFE_DOMAIN;
+    }
+
+    /**
+     * Send-time rewrite target for a non-allow-listed recipient.
+     */
+    public static function rewriteRecipient($email)
+    {
+        $sink = self::sink();
+
+        if (!$sink) {
+            return self::anonymize($email);
+        }
+
+        $email = mb_strtolower(trim($email ?? ''), 'UTF-8');
+        $domain = self::domainOf($email);
+
+        if ($domain === null || self::isAllowed($email)) {
+            return $email;
+        }
+
+        $sink_local = substr($sink, 0, strrpos($sink, '@'));
+        $sink_domain = substr($sink, strrpos($sink, '@') + 1);
+
+        // Already sunk — keep idempotent.
+        if ($domain === $sink_domain && strpos($email, $sink_local.'+') === 0) {
+            return $email;
+        }
+
+        $local = substr($email, 0, strrpos($email, '@'));
+
+        // An already-anonymised address carries its folded domain in the
+        // local part — don't fold example.com in on top of it.
+        $folded = ($domain === self::SAFE_DOMAIN) ? $local : $local.'+'.$domain;
+
+        return self::capLocal($sink_local.'+'.$folded, $email).'@'.$sink_domain;
+    }
+
+    /**
+     * Keep the local part within the RFC limit; past it, drop to a stable
+     * short-hash suffix (uniqueness preserved, reversibility knowingly not).
+     */
+    protected static function capLocal($local, $original)
+    {
+        if (strlen($local) <= self::LOCAL_PART_MAX) {
+            return $local;
+        }
+
+        $hash = substr(sha1($original), 0, self::HASH_LENGTH);
+
+        return substr($local, 0, self::LOCAL_PART_MAX - self::HASH_LENGTH - 1).'+'.$hash;
+    }
+
+    protected static function domainOf($email)
+    {
+        $pos = strrpos($email ?? '', '@');
+
+        if ($pos === false || $pos === 0 || $pos === strlen($email) - 1) {
+            return null;
+        }
+
+        return strtolower(substr($email, $pos + 1));
+    }
+}

--- a/Modules/TestEmailGuard/module.json
+++ b/Modules/TestEmailGuard/module.json
@@ -1,0 +1,22 @@
+{
+    "name": "TestEmailGuard",
+    "alias": "testemailguard",
+    "description": "Test-environment email safety net (ARMS-16). Rewrites outbound recipients to anonymised safe addresses unless the recipient domain is allow-listed, and provides a console command to anonymise stored customer emails. Hard-disabled when app.env is production.",
+    "version": "1.0.0",
+    "detailsUrl": "",
+    "author": "Threls",
+    "authorUrl": "https://threls.com",
+    "requiredAppVersion": "1.8.0",
+    "license": "AGPL-3.0",
+    "keywords": ["testing", "email", "anonymisation"],
+    "active": 0,
+    "order": 0,
+    "providers": [
+        "Modules\\TestEmailGuard\\Providers\\TestEmailGuardServiceProvider"
+    ],
+    "aliases": {},
+    "files": [
+        "start.php"
+    ],
+    "requires": []
+}

--- a/Modules/TestEmailGuard/start.php
+++ b/Modules/TestEmailGuard/start.php
@@ -1,0 +1,11 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| TestEmailGuard module bootstrap
+|--------------------------------------------------------------------------
+|
+| This module has no routes or views — all registration happens in the
+| service provider (Providers/TestEmailGuardServiceProvider.php).
+|
+*/

--- a/app/Conversation.php
+++ b/app/Conversation.php
@@ -586,7 +586,8 @@ class Conversation extends Model
             //     break;
 
             default:
-                return '';
+                // Allows modules to register extra statuses (threls fork patch, ARMS-12).
+                return \Eventy::filter('conversation.status_name', '', $status);
                 break;
         }
     }

--- a/app/Conversation.php
+++ b/app/Conversation.php
@@ -1116,7 +1116,8 @@ class Conversation extends Model
         // Get conversations from personal folder
         if ($folder->type == Folder::TYPE_MINE) {
             $query_conversations = self::where('mailbox_id', $folder->mailbox_id)
-                ->whereIn('status', [self::STATUS_ACTIVE, self::STATUS_PENDING])
+                // Allows modules to register extra open-type statuses (threls fork patch, ARMS-12).
+                ->whereIn('status', \Eventy::filter('conversation.open_statuses', [self::STATUS_ACTIVE, self::STATUS_PENDING]))
                 ->where('state', self::STATE_PUBLISHED);
 
                 // Applied below.
@@ -2529,7 +2530,8 @@ class Conversation extends Model
         $chats = Conversation::where('type', self::TYPE_CHAT)
             ->where('mailbox_id', $mailbox_id)
             ->where('state', self::STATE_PUBLISHED)
-            ->whereIn('status', [self::STATUS_ACTIVE, self::STATUS_PENDING])
+            // Allows modules to register extra open-type statuses (threls fork patch, ARMS-12).
+            ->whereIn('status', \Eventy::filter('conversation.open_statuses', [self::STATUS_ACTIVE, self::STATUS_PENDING]))
             ->orderBy('last_reply_at', 'desc')
             ->offset($offset)
             ->limit($limit)

--- a/app/Conversation.php
+++ b/app/Conversation.php
@@ -1117,7 +1117,7 @@ class Conversation extends Model
         if ($folder->type == Folder::TYPE_MINE) {
             $query_conversations = self::where('mailbox_id', $folder->mailbox_id)
                 // Allows modules to register extra open-type statuses (threls fork patch, ARMS-12).
-                ->whereIn('status', \Eventy::filter('conversation.open_statuses', [self::STATUS_ACTIVE, self::STATUS_PENDING]))
+                ->whereIn('status', (array) \Eventy::filter('conversation.open_statuses', [self::STATUS_ACTIVE, self::STATUS_PENDING]))
                 ->where('state', self::STATE_PUBLISHED);
 
                 // Applied below.
@@ -2531,7 +2531,7 @@ class Conversation extends Model
             ->where('mailbox_id', $mailbox_id)
             ->where('state', self::STATE_PUBLISHED)
             // Allows modules to register extra open-type statuses (threls fork patch, ARMS-12).
-            ->whereIn('status', \Eventy::filter('conversation.open_statuses', [self::STATUS_ACTIVE, self::STATUS_PENDING]))
+            ->whereIn('status', (array) \Eventy::filter('conversation.open_statuses', [self::STATUS_ACTIVE, self::STATUS_PENDING]))
             ->orderBy('last_reply_at', 'desc')
             ->offset($offset)
             ->limit($limit)

--- a/app/Listeners/SendNotificationToUsers.php
+++ b/app/Listeners/SendNotificationToUsers.php
@@ -56,6 +56,11 @@ class SendNotificationToUsers
                 $event_type = Subscription::EVENT_TYPE_ASSIGNED;
                 break;
             case 'App\Events\CustomerReplied':
+                // Do not send notifications to users if customer sent a reply
+                // to the conversation marked as Spam.
+                if (!empty($event->conversation) && $event->conversation->isSpam()) {
+                    return;
+                }
                 $event_type = Subscription::EVENT_TYPE_CUSTOMER_REPLIED;
                 break;
         }

--- a/app/Subscription.php
+++ b/app/Subscription.php
@@ -384,15 +384,22 @@ class Subscription extends Model
             || !empty($notify[self::MEDIUM_BROWSER])
             || !empty($notify[self::MEDIUM_MENU])
         ) {
+            // https://github.com/freescout-help-desk/freescout/issues/5491
+            $notify_menu = [];
             if (!empty($notify[self::MEDIUM_EMAIL])) {
                 $notify_menu = $notify[self::MEDIUM_EMAIL] ?? [];
-            } else {
-                $notify_menu = $notify[self::MEDIUM_BROWSER] ?? [];
+            }
+            foreach ($notify[self::MEDIUM_BROWSER] ?? [] as $conversation_id => $notify_info) {
+                if (empty($notify_menu[$conversation_id])) {
+                    $notify_menu[$conversation_id] = $notify_info;
+                }
             }
             $notify_menu = $notify_menu + ($notify[self::MEDIUM_MENU] ?? []);
+
             foreach ($notify_menu as $notify_info) {
                 $website_notification = new WebsiteNotification($notify_info['conversation'], self::chooseThread($notify_info['threads']));
                 $website_notification->delay($delay);
+
                 \Notification::send($notify_info['users'], $website_notification);
             }
         }
@@ -440,6 +447,8 @@ class Subscription extends Model
      */
     public static function chooseThread($threads)
     {
+        //$last_meaningful_thread = null;
+
         $actions_types = [
             Thread::ACTION_TYPE_USER_CHANGED,
         ];
@@ -448,9 +457,18 @@ class Subscription extends Model
             if ($thread->type == Thread::TYPE_LINEITEM && !in_array($thread->action_type, $actions_types)) {
                 continue;
             } else {
+                // if (!$last_meaningful_thread) {
+                //     $last_meaningful_thread = $thread;
+                // }
+
+                // // Make sure that user is not Deleted to filter out automatic messages.
+                // if (($thread->isUserMessage() || $thread->isNote()) && $thread->created_by_user && $thread->created_by_user->isDeleted()) {
+                //     continue;
+                // }
                 return $thread;
             }
         }
+        //return $last_meaningful_thread ?? $threads[0];
         return $threads[0];
     }
 

--- a/app/Thread.php
+++ b/app/Thread.php
@@ -527,7 +527,9 @@ class Thread extends Model
                 break;
 
             default:
-                return '';
+                // Allows modules to register extra statuses (threls fork patch, ARMS-12).
+                // Status codes are shared with conversations, so the same filter serves both.
+                return \Eventy::filter('conversation.status_name', '', $status);
                 break;
         }
     }

--- a/config/purifier.php
+++ b/config/purifier.php
@@ -23,6 +23,8 @@ return [
     'cacheFileMode' => 0755,
     'settings'      => [
         'default' => [
+            // https://github.com/freescout-help-desk/freescout/issues/5481
+            'Core.EscapeNonASCIICharacters' => true,
             'HTML.Doctype'             => 'HTML 4.01 Transitional',
             'HTML.Allowed'             => 'div[style],b,strong,i,em,u,a[href|title|style],ul,ol,li,p[style],br,span[style],img[width|height|alt|src|style],table[style|border|bgcolor|cellspacing|cellpadding|border|width|class],tr[style|bgcolor],td[style|colspan|rowspan|width|bgcolor|border|valign|align],th[style|colspan|rowspan],thead,tfoot,tbody,blockquote,pre,s,strike,font[style|color],h1[style],h2[style],h3[style],h4[style],h5[style],h6,center',
             'CSS.AllowedProperties'    => 'display,overflow,border-radius,letter-spacing,white-space,font-size,margin,margin-top,margin-right,margin-bottom,margin-left,background,text-transform,max-width,max-height,width,height,font,padding,padding-top,padding-right,padding-bottom,padding-left,font-family,border-color,font-weight,font-style,text-decoration,color,background-color,text-align,border,border-top,border-left,border-bottom,border-right',

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1281,6 +1281,14 @@ function initConversation()
 	    	$(this).addClass('conv-subj-editing');
 		});
 
+		// Save subject on Enter
+		jQuery("#conv-subj-value").on('keydown', function(e){
+			if (e.which == 13) {
+				e.preventDefault();
+				jQuery(".conv-subj-editor button:first").click();
+			}
+		});
+
 		// Save subject
 	    jQuery(".conv-subj-editor button:first").click(function(e){
 	    	var button = $(this);

--- a/tests/Unit/OnHoldStatusTest.php
+++ b/tests/Unit/OnHoldStatusTest.php
@@ -102,9 +102,22 @@ class OnHoldStatusTest extends TestCase
         $this->assertSame($expected, array_keys(Conversation::$status_classes));
         $this->assertSame($expected, array_keys(Conversation::$status_colors));
 
+        // Thread's registry has its own base order (incl. NOCHANGE) — On-Hold
+        // must land right after Pending there too.
+        $expectedThread = [
+            Thread::STATUS_ACTIVE,
+            Thread::STATUS_CLOSED,
+            Thread::STATUS_NOCHANGE,
+            Thread::STATUS_PENDING,
+            self::ONHOLD,
+            Thread::STATUS_SPAM,
+        ];
+        $this->assertSame($expectedThread, array_keys(Thread::$statuses));
+
         // Booting twice must not duplicate or move the entry (idempotency).
         $this->bootModule();
         $this->assertSame($expected, array_keys(Conversation::$statuses));
+        $this->assertSame($expectedThread, array_keys(Thread::$statuses));
     }
 
     public function test_existing_statuses_are_unaffected()

--- a/tests/Unit/OnHoldStatusTest.php
+++ b/tests/Unit/OnHoldStatusTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Conversation;
+use App\Thread;
+use Tests\TestCase;
+
+/**
+ * Covers the OnHoldStatus module (ARMS-12) and the two fork patches it
+ * depends on: the conversation.status_name Eventy filter in the default
+ * case of Conversation::statusCodeToName() and Thread::statusCodeToName().
+ */
+class OnHoldStatusTest extends TestCase
+{
+    const ONHOLD = 5;
+
+    protected $statuses_backup = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The module is not autoloaded while inactive — load the provider directly.
+        require_once __DIR__.'/../../Modules/OnHoldStatus/Providers/OnHoldStatusServiceProvider.php';
+
+        // Static arrays persist across tests in the same process — back them up.
+        $this->statuses_backup = [
+            'statuses'        => Conversation::$statuses,
+            'status_icons'    => Conversation::$status_icons,
+            'status_classes'  => Conversation::$status_classes,
+            'status_colors'   => Conversation::$status_colors,
+            'thread_statuses' => Thread::$statuses,
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        Conversation::$statuses = $this->statuses_backup['statuses'];
+        Conversation::$status_icons = $this->statuses_backup['status_icons'];
+        Conversation::$status_classes = $this->statuses_backup['status_classes'];
+        Conversation::$status_colors = $this->statuses_backup['status_colors'];
+        Thread::$statuses = $this->statuses_backup['thread_statuses'];
+
+        parent::tearDown();
+    }
+
+    protected function bootModule()
+    {
+        (new \Modules\OnHoldStatus\Providers\OnHoldStatusServiceProvider(app()))->boot();
+    }
+
+    /**
+     * Without the module, the fork patch must preserve core behaviour:
+     * unknown status codes render as an empty string.
+     * (The Eventy singleton is rebuilt per test, so no filter is registered here.)
+     */
+    public function test_unknown_status_renders_empty_without_module()
+    {
+        $this->assertSame('', Conversation::statusCodeToName(self::ONHOLD));
+        $this->assertSame('', Thread::statusCodeToName(self::ONHOLD));
+    }
+
+    public function test_module_registers_on_hold_status()
+    {
+        $this->bootModule();
+
+        // Name resolution through the fork-patch filter, on both models.
+        $this->assertSame('On Hold', Conversation::statusCodeToName(self::ONHOLD));
+        $this->assertSame('On Hold', Thread::statusCodeToName(self::ONHOLD));
+
+        // All four Conversation registries + the Thread registry get the status,
+        // so Blade's direct array indexing cannot hit an undefined key.
+        $this->assertArrayHasKey(self::ONHOLD, Conversation::$statuses);
+        $this->assertArrayHasKey(self::ONHOLD, Conversation::$status_icons);
+        $this->assertArrayHasKey(self::ONHOLD, Conversation::$status_classes);
+        $this->assertArrayHasKey(self::ONHOLD, Conversation::$status_colors);
+        $this->assertArrayHasKey(self::ONHOLD, Thread::$statuses);
+
+        // Status-change validation (Conversation::changeStatus) accepts it.
+        $this->assertTrue(array_key_exists(self::ONHOLD, Conversation::$statuses));
+    }
+
+    public function test_existing_statuses_are_unaffected()
+    {
+        $this->bootModule();
+
+        $this->assertSame('Pending', Conversation::statusCodeToName(Conversation::STATUS_PENDING));
+        $this->assertSame('Active', Conversation::statusCodeToName(Conversation::STATUS_ACTIVE));
+        $this->assertSame('Not changed', Thread::statusCodeToName(Thread::STATUS_NOCHANGE));
+
+        // Truly unknown codes still render empty even with the module active.
+        $this->assertSame('', Conversation::statusCodeToName(99));
+    }
+
+    /**
+     * If the module is ever deactivated while status-5 rows exist,
+     * getStatus() must fall back gracefully (core guard, Conversation.php:623)
+     * so Blade's $status_classes[getStatus()] indexing cannot crash.
+     */
+    public function test_get_status_falls_back_for_unregistered_codes()
+    {
+        $conversation = new Conversation();
+        $conversation->status = self::ONHOLD;
+
+        $this->assertSame(Conversation::STATUS_ACTIVE, $conversation->getStatus());
+
+        $this->bootModule();
+
+        $this->assertSame(self::ONHOLD, $conversation->getStatus());
+    }
+}

--- a/tests/Unit/OnHoldStatusTest.php
+++ b/tests/Unit/OnHoldStatusTest.php
@@ -94,6 +94,28 @@ class OnHoldStatusTest extends TestCase
     }
 
     /**
+     * The Mine folder and chat list are live queries filtering on an
+     * "open statuses" whitelist — the module must extend it so On-Hold
+     * conversations do not vanish from the Mine folder (regression found
+     * live on the demo instance, 13 Jul).
+     */
+    public function test_open_statuses_whitelist_includes_on_hold()
+    {
+        // Without the module: core default.
+        $this->assertSame(
+            [Conversation::STATUS_ACTIVE, Conversation::STATUS_PENDING],
+            \Eventy::filter('conversation.open_statuses', [Conversation::STATUS_ACTIVE, Conversation::STATUS_PENDING])
+        );
+
+        $this->bootModule();
+
+        $this->assertContains(
+            self::ONHOLD,
+            \Eventy::filter('conversation.open_statuses', [Conversation::STATUS_ACTIVE, Conversation::STATUS_PENDING])
+        );
+    }
+
+    /**
      * If the module is ever deactivated while status-5 rows exist,
      * getStatus() must fall back gracefully (core guard, Conversation.php:623)
      * so Blade's $status_classes[getStatus()] indexing cannot crash.

--- a/tests/Unit/OnHoldStatusTest.php
+++ b/tests/Unit/OnHoldStatusTest.php
@@ -81,6 +81,32 @@ class OnHoldStatusTest extends TestCase
         $this->assertTrue(array_key_exists(self::ONHOLD, Conversation::$statuses));
     }
 
+    /**
+     * Dropdowns render registry order — On Hold must sit after Pending,
+     * not at the end after Spam (ARMS-14).
+     */
+    public function test_on_hold_is_ordered_after_pending()
+    {
+        $this->bootModule();
+
+        $expected = [
+            Conversation::STATUS_ACTIVE,
+            Conversation::STATUS_PENDING,
+            self::ONHOLD,
+            Conversation::STATUS_CLOSED,
+            Conversation::STATUS_SPAM,
+        ];
+
+        $this->assertSame($expected, array_keys(Conversation::$statuses));
+        $this->assertSame($expected, array_keys(Conversation::$status_icons));
+        $this->assertSame($expected, array_keys(Conversation::$status_classes));
+        $this->assertSame($expected, array_keys(Conversation::$status_colors));
+
+        // Booting twice must not duplicate or move the entry (idempotency).
+        $this->bootModule();
+        $this->assertSame($expected, array_keys(Conversation::$statuses));
+    }
+
     public function test_existing_statuses_are_unaffected()
     {
         $this->bootModule();

--- a/tests/Unit/OnHoldStatusTest.php
+++ b/tests/Unit/OnHoldStatusTest.php
@@ -101,9 +101,11 @@ class OnHoldStatusTest extends TestCase
      */
     public function test_open_statuses_whitelist_includes_on_hold()
     {
-        // Without the module: core default.
-        $this->assertSame(
-            [Conversation::STATUS_ACTIVE, Conversation::STATUS_PENDING],
+        // Without the module, On-Hold must not be in the whitelist.
+        // (assertNotContains rather than asserting the exact default array,
+        // so an unrelated module extending the whitelist doesn't break this.)
+        $this->assertNotContains(
+            self::ONHOLD,
             \Eventy::filter('conversation.open_statuses', [Conversation::STATUS_ACTIVE, Conversation::STATUS_PENDING])
         );
 

--- a/tests/Unit/TestEmailGuardTest.php
+++ b/tests/Unit/TestEmailGuardTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+
+/**
+ * Covers the TestEmailGuard module (ARMS-16): the anonymisation transform,
+ * the allow-list, the sink-mailbox mode and the send-time guard hooked to
+ * core's mail.process_swift_message filter.
+ */
+class TestEmailGuardTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The module is not autoloaded while inactive — load directly.
+        require_once __DIR__.'/../../Modules/TestEmailGuard/Services/EmailAnonymizer.php';
+        require_once __DIR__.'/../../Modules/TestEmailGuard/Providers/TestEmailGuardServiceProvider.php';
+    }
+
+    protected function tearDown(): void
+    {
+        // Clear env overrides set via putenv() in individual tests.
+        putenv('TEST_EMAIL_GUARD_SINK');
+        putenv('TEST_EMAIL_GUARD_ALLOW_DOMAINS');
+
+        parent::tearDown();
+    }
+
+    protected function bootModule()
+    {
+        (new \Modules\TestEmailGuard\Providers\TestEmailGuardServiceProvider(app()))->boot();
+    }
+
+    protected function anonymizer()
+    {
+        return \Modules\TestEmailGuard\Services\EmailAnonymizer::class;
+    }
+
+    public function test_folds_domain_into_local_part()
+    {
+        $this->assertSame(
+            'tanti.omar+gmail.com@example.com',
+            $this->anonymizer()::anonymize('tanti.omar@gmail.com')
+        );
+    }
+
+    public function test_distinct_addresses_stay_distinct()
+    {
+        $this->assertNotSame(
+            $this->anonymizer()::anonymize('john@gmail.com'),
+            $this->anonymizer()::anonymize('john@yahoo.com')
+        );
+    }
+
+    public function test_transform_is_idempotent()
+    {
+        $once = $this->anonymizer()::anonymize('tanti.omar@gmail.com');
+
+        $this->assertSame($once, $this->anonymizer()::anonymize($once));
+    }
+
+    public function test_lowercases_consistently()
+    {
+        $this->assertSame(
+            'john.doe+gmail.com@example.com',
+            $this->anonymizer()::anonymize('John.DOE@Gmail.COM')
+        );
+    }
+
+    public function test_allow_listed_domains_pass_through()
+    {
+        $this->assertSame('anthea@arms.com.mt', $this->anonymizer()::anonymize('anthea@arms.com.mt'));
+        $this->assertSame('omar@threls.com', $this->anonymizer()::anonymize('Omar@Threls.com'));
+    }
+
+    /**
+     * The allow-list matches exact domains only — neither a subdomain of an
+     * allowed domain nor a lookalike suffix may receive real mail.
+     */
+    public function test_allow_list_is_exact_domain_match()
+    {
+        $this->assertStringEndsWith('@example.com', $this->anonymizer()::anonymize('user@sub.arms.com.mt'));
+        $this->assertStringEndsWith('@example.com', $this->anonymizer()::anonymize('user@arms.com.mt.attacker.net'));
+    }
+
+    public function test_allow_list_is_env_overridable()
+    {
+        putenv('TEST_EMAIL_GUARD_ALLOW_DOMAINS=arms.com.mt, threls.com, threls.onmicrosoft.com');
+
+        $this->assertSame(
+            'customercare@threls.onmicrosoft.com',
+            $this->anonymizer()::anonymize('customercare@threls.onmicrosoft.com')
+        );
+    }
+
+    public function test_long_local_parts_fall_back_to_hash_within_rfc_limit()
+    {
+        $email_a = str_repeat('a', 60).'@a-very-long-corporate-subdomain.example-company.co.uk';
+        $email_b = str_repeat('a', 60).'@another-long-corporate-subdomain.example-company.co.uk';
+
+        $result_a = $this->anonymizer()::anonymize($email_a);
+        $result_b = $this->anonymizer()::anonymize($email_b);
+
+        foreach ([$result_a, $result_b] as $result) {
+            $local = substr($result, 0, strrpos($result, '@'));
+            $this->assertLessThanOrEqual(64, strlen($local));
+            $this->assertStringEndsWith('@example.com', $result);
+        }
+
+        // Same truncated local prefix, but the hash keeps them distinct.
+        $this->assertNotSame($result_a, $result_b);
+    }
+
+    public function test_invalid_input_passes_through_unchanged()
+    {
+        $this->assertSame('', $this->anonymizer()::anonymize(''));
+        $this->assertSame('not-an-email', $this->anonymizer()::anonymize('not-an-email'));
+    }
+
+    public function test_sink_mode_plus_addresses_into_the_sink_mailbox()
+    {
+        putenv('TEST_EMAIL_GUARD_SINK=armssink@threls.onmicrosoft.com');
+
+        $this->assertSame(
+            'armssink+tanti.omar+gmail.com@threls.onmicrosoft.com',
+            $this->anonymizer()::rewriteRecipient('tanti.omar@gmail.com')
+        );
+
+        // Allow-listed recipients are still delivered normally.
+        $this->assertSame('anthea@arms.com.mt', $this->anonymizer()::rewriteRecipient('anthea@arms.com.mt'));
+
+        // A stored, already-anonymised address folds into the sink without
+        // dragging example.com along, and the rewrite is idempotent.
+        $sunk = $this->anonymizer()::rewriteRecipient('tanti.omar+gmail.com@example.com');
+        $this->assertSame('armssink+tanti.omar+gmail.com@threls.onmicrosoft.com', $sunk);
+        $this->assertSame($sunk, $this->anonymizer()::rewriteRecipient($sunk));
+    }
+
+    public function test_without_sink_rewrite_targets_example_com()
+    {
+        $this->assertSame(
+            'tanti.omar+gmail.com@example.com',
+            $this->anonymizer()::rewriteRecipient('tanti.omar@gmail.com')
+        );
+    }
+
+    public function test_guard_rewrites_swift_message_recipients()
+    {
+        $this->bootModule();
+
+        $message = new \Swift_Message('Test');
+        $message->setTo(['customer@gmail.com' => 'Some Customer', 'omar@threls.com' => 'Omar']);
+        $message->setCc(['other@yahoo.com' => null]);
+
+        $proceed = \Eventy::filter('mail.process_swift_message', true, $message);
+
+        $this->assertTrue($proceed);
+        $this->assertSame(
+            ['customer+gmail.com@example.com' => 'Some Customer', 'omar@threls.com' => 'Omar'],
+            $message->getTo()
+        );
+        $this->assertSame(['other+yahoo.com@example.com' => null], $message->getCc());
+    }
+
+    /**
+     * Hard environment gate: even with the module active, production
+     * messages must pass through untouched.
+     */
+    public function test_guard_does_nothing_in_production()
+    {
+        $this->bootModule();
+
+        $env_backup = config('app.env');
+        config(['app.env' => 'production']);
+
+        try {
+            $message = new \Swift_Message('Test');
+            $message->setTo(['customer@gmail.com' => 'Some Customer']);
+
+            $proceed = \Eventy::filter('mail.process_swift_message', true, $message);
+
+            $this->assertTrue($proceed);
+            $this->assertSame(['customer@gmail.com' => 'Some Customer'], $message->getTo());
+        } finally {
+            config(['app.env' => $env_backup]);
+        }
+    }
+
+    /**
+     * The guard must not overturn another listener's decision to cancel
+     * a send.
+     */
+    public function test_guard_preserves_cancelled_sends()
+    {
+        $this->bootModule();
+
+        $message = new \Swift_Message('Test');
+        $message->setTo(['customer@gmail.com' => null]);
+
+        $this->assertFalse(\Eventy::filter('mail.process_swift_message', false, $message));
+        $this->assertSame(['customer@gmail.com' => null], $message->getTo());
+    }
+}


### PR DESCRIPTION
Right now, if ARMS start bulk-testing on the demo with realistic data, every reply, auto-reply and workflow email would go to the actual customer addresses in that data. Real people would get email from a test system. This closes that off.

With the new TestEmailGuard module active, any outgoing email to an address we haven't allow-listed gets rewritten to a safe fake address before it leaves. Mail to @arms.com.mt and @threls.com still goes out normally, so the team receives real email while testing. The rewriting keeps different customers distinct (john@gmail.com and john@yahoo.com don't collapse into the same fake address), which matters once we import real ticket data and need customer records to stay separate.

Where the rewritten mail goes is configurable. Out of the box it points at a reserved dead domain, which works but produces bounce-backs that clutter the inboxes during heavy testing. The better setup is a sink mailbox we control, where every outgoing email actually arrives and can be opened and checked. That's a one-line setting once the mailbox exists.

There's also a command to scrub customer addresses already sitting in the database (for after the Zendesk trial migration, so no real addresses are stored at all), and a status command that says plainly whether the guard is on and where mail is being redirected.

Safety: the guard flat-out refuses to run in an environment that calls itself production, even if someone activates the module there by mistake. One catch worth knowing: our demo server currently calls itself production too (Forge's default), so before relying on the guard we need to change that one setting on the demo and run the status command to confirm. It's in the README.

Tested: the address rewriting (uniqueness, repeat-safety, casing, the 64-character edge case), allow-listed mail passing through untouched, lookalike domains not slipping through, the sink mode, and the production refusal. 14 new tests, existing tests unaffected.

Not included on purpose: nothing changes in production behaviour, and agents' own accounts are never touched.