### PR TITLE
Prevent forwarded notifications from replying to customers

### DIFF
--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -552,7 +552,7 @@ class FetchEmails extends Command
             // in In-Reply-To/References or in the hidden marker. Do not attach such
             // forwards to the original conversation, otherwise the original
             // customer may receive the forwarded internal message.
-            if ($this->shouldStartNewConversationForForward($subject, $prev_message_ids)) {
+            if ($this->shouldStartNewConversationForForward($subject, $prev_message_ids, $in_reply_to)) {
                 $this->line('['.date('Y-m-d H:i:s').'] Forwarded FreeScout notification detected. Creating a new conversation.');
                 $prev_message_ids = [];
             }
@@ -1051,25 +1051,60 @@ class FetchEmails extends Command
      * Body text is deliberately not inspected: notification emails can contain
      * arbitrary conversation history, including forwarded-message separators.
      */
-    public function shouldStartNewConversationForForward($subject, array $prev_message_ids)
+    public function shouldStartNewConversationForForward($subject, array $prev_message_ids, $in_reply_to = '')
     {
-        if (!preg_match('/^\s*(fwd?|fw|wg|vs|rv|tr|enc|red|doorst|vl|sv|转发|轉寄|転送)\s*:/iu', trim($subject ?? ''))) {
+        if (!preg_match('/^\s*(fwd?|fw|wg|vs|rv|tr|enc|red|doorst|vl|sv|转发|轉寄|転送)\s*:\s*(.*)$/iu', trim($subject ?? ''), $subject_matches)) {
             return false;
         }
 
-        // Include notification IDs without the FS_ prefix for compatibility.
-        $prefix = $this->formatMessageIdPrefix(preg_quote(Mail::MESSAGE_ID_PREFIX_NOTIFICATION, '/'));
+        // A reply can keep an original subject that already starts with "Fwd:".
+        // In-Reply-To pointing to the notification is a stronger reply signal
+        // than the subject prefix and must preserve the existing conversation.
+        if ($this->getUserNotificationThreadId($in_reply_to)) {
+            return false;
+        }
+
         foreach ($prev_message_ids as $prev_message_id) {
-            preg_match('/^'.$prefix.'\-(\d+)\-\d+\-([a-z0-9]{16})@/i', $prev_message_id ?? '', $matches);
-            if (!empty($matches[1])
-                && !empty($matches[2])
-                && hash_equals(Mail::getMessageIdHash($matches[1]), $matches[2])
-            ) {
+            $thread_id = $this->getUserNotificationThreadId($prev_message_id);
+            if (!$thread_id || !($prev_thread = Thread::find($thread_id)) || !$prev_thread->conversation) {
+                continue;
+            }
+
+            // A real forward adds a forward prefix to the notification subject.
+            // Merely having an original conversation subject beginning with "Fwd:"
+            // must not turn a normal reply into a new conversation.
+            $forwarded_subject = trim($subject_matches[2]);
+            $conversation = $prev_thread->conversation;
+            $forwarded_subject = preg_replace(
+                '/^\[#'.preg_quote($conversation->number, '/').'\]\s*/u',
+                '',
+                $forwarded_subject
+            );
+            if ($forwarded_subject === trim($conversation->subject ?? '')) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * Validate a user notification Message-ID and return its thread ID.
+     * Includes IDs without the FS_ prefix for compatibility.
+     */
+    public function getUserNotificationThreadId($message_id)
+    {
+        $prefix = $this->formatMessageIdPrefix(preg_quote(Mail::MESSAGE_ID_PREFIX_NOTIFICATION, '/'));
+        preg_match('/^'.$prefix.'\-(\d+)\-\d+\-([a-z0-9]{16})@/i', $message_id ?? '', $matches);
+
+        if (!empty($matches[1])
+            && !empty($matches[2])
+            && hash_equals(Mail::getMessageIdHash($matches[1]), $matches[2])
+        ) {
+            return $matches[1];
+        }
+
+        return null;
     }
 
     // Try to get "From:" from body.

--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -498,6 +498,16 @@ class FetchEmails extends Command
             $attachments = $message->getAttachments();
             $html_body = '';
 
+            // Webklex/php-imap returns object instead of a string.
+            // Normalize the subject before threading detection so forwarded
+            // notification emails are not attached to the original conversation.
+            $subject = $message->getSubject()."";
+
+            // Convert subject encoding.
+            if (preg_match('/=\?[a-z\d-]+\?[BQ]\?.*\?=/i', $subject)) {
+                $subject = \Helper::iconvMimeDecode($subject);
+            }
+
             // Is it a bounce message
             $is_bounce = false;
 
@@ -535,6 +545,16 @@ class FetchEmails extends Command
             $marker_message_id = \MailHelper::fetchMessageMarkerValue($html_body);
             if ($marker_message_id) {
                 $prev_message_ids[] = $marker_message_id;
+            }
+
+            // If a support agent forwards a FreeScout notification to a mailbox,
+            // the forwarded message may still contain the notification Message-ID
+            // in In-Reply-To/References or in the hidden marker. Do not attach such
+            // forwards to the original conversation, otherwise the original
+            // customer may receive the forwarded internal message.
+            if ($this->shouldStartNewConversationForForward($subject, $prev_message_ids)) {
+                $this->line('['.date('Y-m-d H:i:s').'] Forwarded FreeScout notification detected. Creating a new conversation.');
+                $prev_message_ids = [];
             }
 
             // Bounce detection.
@@ -826,14 +846,6 @@ class FetchEmails extends Command
             //     continue;
             // }
 
-            // Webklex/php-imap returns object instead of a string.
-            $subject = $message->getSubject()."";
-
-            // Convert subject encoding
-            if (preg_match('/=\?[a-z\d-]+\?[BQ]\?.*\?=/i', $subject)) {
-                $subject = \Helper::iconvMimeDecode($subject);
-            }
-
             $to = $this->formatEmailList($message->getTo());
 
             $cc = $this->formatEmailList($message->getCc());
@@ -1032,6 +1044,32 @@ class FetchEmails extends Command
     public function formatMessageIdPrefix($prefix)
     {
         return str_replace('FS_', '(?:FS_)?', $prefix);
+    }
+
+    /**
+     * Determine whether a forwarded user notification must start a new conversation.
+     * Body text is deliberately not inspected: notification emails can contain
+     * arbitrary conversation history, including forwarded-message separators.
+     */
+    public function shouldStartNewConversationForForward($subject, array $prev_message_ids)
+    {
+        if (!preg_match('/^\s*(fwd?|fw|wg|vs|rv|tr|enc|red|doorst|vl|sv|转发|轉寄|転送)\s*:/iu', trim($subject ?? ''))) {
+            return false;
+        }
+
+        // Include notification IDs without the FS_ prefix for compatibility.
+        $prefix = $this->formatMessageIdPrefix(preg_quote(Mail::MESSAGE_ID_PREFIX_NOTIFICATION, '/'));
+        foreach ($prev_message_ids as $prev_message_id) {
+            preg_match('/^'.$prefix.'\-(\d+)\-\d+\-([a-z0-9]{16})@/i', $prev_message_id ?? '', $matches);
+            if (!empty($matches[1])
+                && !empty($matches[2])
+                && hash_equals(Mail::getMessageIdHash($matches[1]), $matches[2])
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // Try to get "From:" from body.

--- a/tests/Feature/ForwardedNotificationTest.php
+++ b/tests/Feature/ForwardedNotificationTest.php
@@ -44,6 +44,7 @@ class ForwardedNotificationTest extends TestCase
             'folder_id'      => $this->mailbox_a->getFolderByType(Folder::TYPE_UNASSIGNED)->id,
             'customer_id'    => $customer->id,
             'customer_email' => 'customer@example.org',
+            'subject'        => 'Question about invoice 123',
             'status'         => Conversation::STATUS_ACTIVE,
         ]);
         $this->thread = factory(Thread::class)->create([
@@ -57,8 +58,9 @@ class ForwardedNotificationTest extends TestCase
     public function testForwardedNotificationWithSecondMailboxInCcCreatesNewConversation()
     {
         Queue::fake();
+        $forwarded_subject = 'Fwd: [#'.$this->conversation->number.'] Question about invoice 123';
         $message = $this->notificationResponseMessage(
-            'Fwd: Question about invoice 123',
+            $forwarded_subject,
             'Supervisor <supervisor@example.org>',
             'Mailbox B <'.$this->mailbox_b->email.'>'
         );
@@ -69,7 +71,7 @@ class ForwardedNotificationTest extends TestCase
             ->first();
 
         self::assertNotNull($new_conversation);
-        self::assertSame('Fwd: Question about invoice 123', $new_conversation->subject);
+        self::assertSame($forwarded_subject, $new_conversation->subject);
         self::assertSame('agent@example.org', $new_conversation->customer_email);
         self::assertContains('supervisor@example.org', $new_conversation->getCcArray());
         self::assertNotContains('customer@example.org', $new_conversation->getCcArray());
@@ -102,7 +104,9 @@ class ForwardedNotificationTest extends TestCase
             'Re: Question about invoice 123',
             'Mailbox A <'.$this->mailbox_a->email.'>',
             null,
-            'Reply to the customer. Begin forwarded message: quoted history.'
+            'Reply to the customer. Begin forwarded message: quoted history.',
+            true,
+            true
         );
         $this->processMessage($message, $this->mailbox_a, 'notification-reply@example.org');
 
@@ -117,6 +121,47 @@ class ForwardedNotificationTest extends TestCase
         });
     }
 
+    public function testReplyToCustomerMessageWhoseSubjectStartsWithForwardPrefix()
+    {
+        Queue::fake();
+        $this->conversation->subject = 'Fwd: Test';
+        $this->conversation->save();
+
+        $message = $this->notificationResponseMessage(
+            'Fwd: Test',
+            'Mailbox A <'.$this->mailbox_a->email.'>',
+            null,
+            'Reply to the customer.',
+            true,
+            false
+        );
+        $this->processMessage($message, $this->mailbox_a, 'forward-subject-reply@example.org');
+
+        self::assertSame(1, Conversation::whereIn('mailbox_id', [$this->mailbox_a->id, $this->mailbox_b->id])->count());
+        self::assertSame(2, $this->conversation->threads()->count());
+        Queue::assertPushed(SendReplyToCustomerJob::class, function ($job) {
+            return $job->conversation->id == $this->conversation->id;
+        });
+    }
+
+    public function testForwardOfCustomerMessageWhoseSubjectStartsWithForwardPrefix()
+    {
+        Queue::fake();
+        $this->conversation->subject = 'Fwd: Test';
+        $this->conversation->save();
+
+        $message = $this->notificationResponseMessage(
+            'Fwd: [#'.$this->conversation->number.'] Fwd: Test',
+            'Supervisor <supervisor@example.org>',
+            'Mailbox B <'.$this->mailbox_b->email.'>'
+        );
+        $this->processMessage($message, $this->mailbox_b, 'double-forward-subject@example.org');
+
+        self::assertNotNull(Conversation::where('mailbox_id', $this->mailbox_b->id)->first());
+        self::assertSame(1, $this->conversation->threads()->count());
+        Queue::assertNotPushed(SendReplyToCustomerJob::class);
+    }
+
     public function testReplyToNotificationStillWorksAfterConversationWasMoved()
     {
         Queue::fake();
@@ -126,7 +171,11 @@ class ForwardedNotificationTest extends TestCase
 
         $message = $this->notificationResponseMessage(
             'Re: Question about invoice 123',
-            'Mailbox A <'.$this->mailbox_a->email.'>'
+            'Mailbox A <'.$this->mailbox_a->email.'>',
+            null,
+            'Reply to the customer.',
+            true,
+            true
         );
         $this->processMessage($message, $this->mailbox_a, 'moved-conversation-reply@example.org');
 
@@ -148,7 +197,7 @@ class ForwardedNotificationTest extends TestCase
         return $mailbox;
     }
 
-    private function notificationResponseMessage($subject, $to, $cc = null, $new_body = 'Internal note for the supervisor.', $include_references = true)
+    private function notificationResponseMessage($subject, $to, $cc = null, $new_body = 'Internal note for the supervisor.', $include_references = true, $include_in_reply_to = false)
     {
         $notification_id = Mail::MESSAGE_ID_PREFIX_NOTIFICATION
             .'-'.$this->thread->id
@@ -158,11 +207,13 @@ class ForwardedNotificationTest extends TestCase
         $marker = Mail::getMessageMarker($notification_id);
         $cc_header = $cc ? "Cc: {$cc}\r\n" : '';
         $references_header = $include_references ? "References: <{$notification_id}>\r\n" : '';
+        $in_reply_to_header = $include_in_reply_to ? "In-Reply-To: <{$notification_id}>\r\n" : '';
         $eml = "From: Agent <{$this->agent->email}>\r\n"
             ."To: {$to}\r\n"
             .$cc_header
             ."Subject: {$subject}\r\n"
             ."Message-ID: <notification-response@example.org>\r\n"
+            .$in_reply_to_header
             .$references_header
             ."Date: Mon, 20 Jul 2026 12:00:00 +0000\r\n"
             ."MIME-Version: 1.0\r\n"

--- a/tests/Feature/ForwardedNotificationTest.php
+++ b/tests/Feature/ForwardedNotificationTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Console\Commands\FetchEmails;
+use App\Conversation;
+use App\Customer;
+use App\Folder;
+use App\Jobs\SendReplyToCustomer as SendReplyToCustomerJob;
+use App\Mailbox;
+use App\Misc\Mail;
+use App\Thread;
+use App\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+use Webklex\PHPIMAP\ClientManager;
+use Webklex\PHPIMAP\Message;
+
+class ForwardedNotificationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private $agent;
+    private $mailbox_a;
+    private $mailbox_b;
+    private $conversation;
+    private $thread;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->agent = factory(User::class)->create([
+            'email' => 'agent@example.org',
+        ]);
+        $this->mailbox_a = $this->createMailbox('mailbox-a@example.org');
+        $this->mailbox_b = $this->createMailbox('mailbox-b@example.org');
+        $customer = factory(Customer::class)->create();
+        $customer->syncEmails(['customer@example.org']);
+
+        $this->conversation = factory(Conversation::class)->create([
+            'mailbox_id'     => $this->mailbox_a->id,
+            'folder_id'      => $this->mailbox_a->getFolderByType(Folder::TYPE_UNASSIGNED)->id,
+            'customer_id'    => $customer->id,
+            'customer_email' => 'customer@example.org',
+            'status'         => Conversation::STATUS_ACTIVE,
+        ]);
+        $this->thread = factory(Thread::class)->create([
+            'conversation_id' => $this->conversation->id,
+            'customer_id'     => $customer->id,
+            'message_id'      => 'customer-message@example.org',
+            'to'              => 'customer@example.org',
+        ]);
+    }
+
+    public function testForwardedNotificationWithSecondMailboxInCcCreatesNewConversation()
+    {
+        Queue::fake();
+        $message = $this->notificationResponseMessage(
+            'Fwd: Question about invoice 123',
+            'Supervisor <supervisor@example.org>',
+            'Mailbox B <'.$this->mailbox_b->email.'>'
+        );
+        $this->processMessage($message, $this->mailbox_b, 'forwarded-notification@example.org');
+
+        $new_conversation = Conversation::where('mailbox_id', $this->mailbox_b->id)
+            ->where('id', '<>', $this->conversation->id)
+            ->first();
+
+        self::assertNotNull($new_conversation);
+        self::assertSame('Fwd: Question about invoice 123', $new_conversation->subject);
+        self::assertSame('agent@example.org', $new_conversation->customer_email);
+        self::assertContains('supervisor@example.org', $new_conversation->getCcArray());
+        self::assertNotContains('customer@example.org', $new_conversation->getCcArray());
+        self::assertSame(1, Conversation::where('mailbox_id', $this->mailbox_a->id)->count());
+        self::assertSame(1, $this->conversation->threads()->count());
+        Queue::assertNotPushed(SendReplyToCustomerJob::class);
+    }
+
+    public function testForwardedNotificationUsesHiddenMarkerWhenReplyHeadersAreRemoved()
+    {
+        Queue::fake();
+        $message = $this->notificationResponseMessage(
+            'Fwd: Question about invoice 123',
+            'Supervisor <supervisor@example.org>',
+            'Mailbox B <'.$this->mailbox_b->email.'>',
+            'Internal note for the supervisor.',
+            false
+        );
+        $this->processMessage($message, $this->mailbox_b, 'forwarded-notification-without-references@example.org');
+
+        self::assertNotNull(Conversation::where('mailbox_id', $this->mailbox_b->id)->first());
+        self::assertSame(1, $this->conversation->threads()->count());
+        Queue::assertNotPushed(SendReplyToCustomerJob::class);
+    }
+
+    public function testNormalReplyStillUpdatesOriginalConversation()
+    {
+        Queue::fake();
+        $message = $this->notificationResponseMessage(
+            'Re: Question about invoice 123',
+            'Mailbox A <'.$this->mailbox_a->email.'>',
+            null,
+            'Reply to the customer. Begin forwarded message: quoted history.'
+        );
+        $this->processMessage($message, $this->mailbox_a, 'notification-reply@example.org');
+
+        self::assertSame(1, Conversation::whereIn('mailbox_id', [$this->mailbox_a->id, $this->mailbox_b->id])->count());
+        self::assertSame(2, $this->conversation->threads()->count());
+        $reply = $this->conversation->threads()->orderBy('id', 'desc')->first();
+        self::assertSame(Thread::TYPE_MESSAGE, $reply->type);
+        self::assertSame($this->agent->id, $reply->created_by_user_id);
+        Queue::assertPushed(SendReplyToCustomerJob::class, function ($job) {
+            return $job->conversation->id == $this->conversation->id
+                && $job->customer->getMainEmail() == 'customer@example.org';
+        });
+    }
+
+    public function testReplyToNotificationStillWorksAfterConversationWasMoved()
+    {
+        Queue::fake();
+        $this->conversation->mailbox_id = $this->mailbox_b->id;
+        $this->conversation->folder_id = $this->mailbox_b->getFolderByType(Folder::TYPE_UNASSIGNED)->id;
+        $this->conversation->save();
+
+        $message = $this->notificationResponseMessage(
+            'Re: Question about invoice 123',
+            'Mailbox A <'.$this->mailbox_a->email.'>'
+        );
+        $this->processMessage($message, $this->mailbox_a, 'moved-conversation-reply@example.org');
+
+        self::assertSame(1, Conversation::whereIn('mailbox_id', [$this->mailbox_a->id, $this->mailbox_b->id])->count());
+        self::assertSame($this->mailbox_b->id, $this->conversation->fresh()->mailbox_id);
+        self::assertSame(2, $this->conversation->threads()->count());
+        Queue::assertPushed(SendReplyToCustomerJob::class, function ($job) {
+            return $job->conversation->id == $this->conversation->id;
+        });
+    }
+
+    private function createMailbox($email)
+    {
+        $mailbox = factory(Mailbox::class)->create([
+            'email' => $email,
+        ]);
+        $mailbox->createPublicFolders();
+
+        return $mailbox;
+    }
+
+    private function notificationResponseMessage($subject, $to, $cc = null, $new_body = 'Internal note for the supervisor.', $include_references = true)
+    {
+        $notification_id = Mail::MESSAGE_ID_PREFIX_NOTIFICATION
+            .'-'.$this->thread->id
+            .'-'.$this->agent->id
+            .'-'.Mail::getMessageIdHash($this->thread->id)
+            .'@example.org';
+        $marker = Mail::getMessageMarker($notification_id);
+        $cc_header = $cc ? "Cc: {$cc}\r\n" : '';
+        $references_header = $include_references ? "References: <{$notification_id}>\r\n" : '';
+        $eml = "From: Agent <{$this->agent->email}>\r\n"
+            ."To: {$to}\r\n"
+            .$cc_header
+            ."Subject: {$subject}\r\n"
+            ."Message-ID: <notification-response@example.org>\r\n"
+            .$references_header
+            ."Date: Mon, 20 Jul 2026 12:00:00 +0000\r\n"
+            ."MIME-Version: 1.0\r\n"
+            ."Content-Type: text/html; charset=UTF-8\r\n\r\n"
+            ."<html><body><p>{$new_body}</p>"
+            .'<div id="'.Mail::REPLY_SEPARATOR_NOTIFICATION.'">'
+            ."<div style=\"display:none\">{$marker}</div></div></body></html>";
+
+        new ClientManager(config('imap'));
+        $path = tempnam(sys_get_temp_dir(), 'freescout-issue-4515-');
+        file_put_contents($path, $eml);
+        $message = Message::fromFile($path);
+        unlink($path);
+
+        return $message;
+    }
+
+    private function processMessage($message, $mailbox, $message_id)
+    {
+        $command = new FetchEmailsForTest();
+        $command->mailbox = $mailbox;
+        $command->processMessage(
+            $message,
+            $message_id,
+            $mailbox,
+            collect([$this->mailbox_a, $this->mailbox_b])
+        );
+    }
+}
+
+class FetchEmailsForTest extends FetchEmails
+{
+    public function line($string, $style = null, $verbosity = null)
+    {
+        // Suppress console output in tests.
+    }
+
+    public function setSeen($message, $mailbox)
+    {
+        // A message loaded from an EML fixture has no IMAP server connection.
+    }
+}

--- a/tests/Unit/FetchEmailsForwardDetectionTest.php
+++ b/tests/Unit/FetchEmailsForwardDetectionTest.php
@@ -8,17 +8,7 @@ use Tests\TestCase;
 
 class FetchEmailsForwardDetectionTest extends TestCase
 {
-    public function testForwardedNotificationStartsNewConversation()
-    {
-        $command = new FetchEmails();
-        $message_id = $this->notificationMessageId();
-
-        self::assertTrue($command->shouldStartNewConversationForForward('Fwd: Notification', [$message_id]));
-        self::assertTrue($command->shouldStartNewConversationForForward('FW: Notification', [$message_id]));
-        self::assertTrue($command->shouldStartNewConversationForForward('WG: Notification', [$message_id]));
-    }
-
-    public function testReplyToNotificationKeepsExistingThreadingBehavior()
+    public function testReplySubjectsKeepExistingThreadingBehavior()
     {
         $command = new FetchEmails();
         $message_id = $this->notificationMessageId();
@@ -27,27 +17,30 @@ class FetchEmailsForwardDetectionTest extends TestCase
         self::assertFalse($command->shouldStartNewConversationForForward('Aw: Notification', [$message_id]));
     }
 
-    public function testOnlyValidUserNotificationMessageIdsAreHandled()
+    public function testReplyKeepsOriginalForwardedSubjectWhenInReplyToIsPresent()
     {
         $command = new FetchEmails();
         $message_id = $this->notificationMessageId();
 
-        self::assertTrue($command->shouldStartNewConversationForForward('Fwd: Notification', [
-            'unrelated@example.org',
-            $message_id,
-        ]));
-        self::assertTrue($command->shouldStartNewConversationForForward('Fwd: Notification', [
-            preg_replace('/^FS_/', '', $message_id),
-        ]));
-        self::assertFalse($command->shouldStartNewConversationForForward('Fwd: Notification', [
-            'FS_notify-123-456-0000000000000000@example.org',
-        ]));
-        self::assertFalse($command->shouldStartNewConversationForForward('Fwd: Customer reply', [
-            'FS_reply-123-'.Mail::getMessageIdHash(123).'@example.org',
-        ]));
-        self::assertFalse($command->shouldStartNewConversationForForward('Fwd: Notification', [
-            'regular-message@example.org',
-        ]));
+        self::assertFalse($command->shouldStartNewConversationForForward(
+            'Fwd: Test',
+            [$message_id],
+            $message_id
+        ));
+    }
+
+    public function testOnlyValidUserNotificationMessageIdsAreAccepted()
+    {
+        $command = new FetchEmails();
+        $message_id = $this->notificationMessageId();
+
+        self::assertSame('123', $command->getUserNotificationThreadId($message_id));
+        self::assertSame('123', $command->getUserNotificationThreadId(preg_replace('/^FS_/', '', $message_id)));
+        self::assertNull($command->getUserNotificationThreadId('FS_notify-123-456-0000000000000000@example.org'));
+        self::assertNull($command->getUserNotificationThreadId(
+            'FS_reply-123-'.Mail::getMessageIdHash(123).'@example.org'
+        ));
+        self::assertNull($command->getUserNotificationThreadId('regular-message@example.org'));
     }
 
     private function notificationMessageId()

--- a/tests/Unit/FetchEmailsForwardDetectionTest.php
+++ b/tests/Unit/FetchEmailsForwardDetectionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Console\Commands\FetchEmails;
+use App\Misc\Mail;
+use Tests\TestCase;
+
+class FetchEmailsForwardDetectionTest extends TestCase
+{
+    public function testForwardedNotificationStartsNewConversation()
+    {
+        $command = new FetchEmails();
+        $message_id = $this->notificationMessageId();
+
+        self::assertTrue($command->shouldStartNewConversationForForward('Fwd: Notification', [$message_id]));
+        self::assertTrue($command->shouldStartNewConversationForForward('FW: Notification', [$message_id]));
+        self::assertTrue($command->shouldStartNewConversationForForward('WG: Notification', [$message_id]));
+    }
+
+    public function testReplyToNotificationKeepsExistingThreadingBehavior()
+    {
+        $command = new FetchEmails();
+        $message_id = $this->notificationMessageId();
+
+        self::assertFalse($command->shouldStartNewConversationForForward('Re: Notification', [$message_id]));
+        self::assertFalse($command->shouldStartNewConversationForForward('Aw: Notification', [$message_id]));
+    }
+
+    public function testOnlyValidUserNotificationMessageIdsAreHandled()
+    {
+        $command = new FetchEmails();
+        $message_id = $this->notificationMessageId();
+
+        self::assertTrue($command->shouldStartNewConversationForForward('Fwd: Notification', [
+            'unrelated@example.org',
+            $message_id,
+        ]));
+        self::assertTrue($command->shouldStartNewConversationForForward('Fwd: Notification', [
+            preg_replace('/^FS_/', '', $message_id),
+        ]));
+        self::assertFalse($command->shouldStartNewConversationForForward('Fwd: Notification', [
+            'FS_notify-123-456-0000000000000000@example.org',
+        ]));
+        self::assertFalse($command->shouldStartNewConversationForForward('Fwd: Customer reply', [
+            'FS_reply-123-'.Mail::getMessageIdHash(123).'@example.org',
+        ]));
+        self::assertFalse($command->shouldStartNewConversationForForward('Fwd: Notification', [
+            'regular-message@example.org',
+        ]));
+    }
+
+    private function notificationMessageId()
+    {
+        return 'FS_notify-123-456-'.Mail::getMessageIdHash(123).'@example.org';
+    }
+}


### PR DESCRIPTION
Fixes #4515.

## Summary

When a support agent forwards a FreeScout user notification to another FreeScout mailbox, mail clients may preserve the notification Message-ID in `In-Reply-To`, `References`, or the hidden body marker. FreeScout then treats the forward as an agent reply and may send the internal text to the original customer.

This change detects forwarded user notifications before conversation threading and starts a new conversation instead of attaching the message to the original conversation.

## Safety

- Applies only when the subject has a recognized forward prefix and a valid `FS_notify` Message-ID is present.
- Validates the notification hash using `Mail::getMessageIdHash()`.
- Does not change normal notification replies or `FS_reply` handling.
- Does not inspect arbitrary body text for forwarding markers, avoiding false positives from quoted conversation history.
- Supports a second FreeScout mailbox in CC.

Email has no standardized forward header, so subject-prefix detection is intentionally a pragmatic heuristic. If a sender removes or replaces the forward prefix with an unknown prefix, the forward cannot be distinguished reliably from a reply.

## Tests

Added unit and integration coverage for:

- Forwarded notification to Mailbox B in CC creates a new conversation.
- No `SendReplyToCustomer` job is dispatched for the original customer.
- Hidden FreeScout marker fallback when reply headers are removed.
- Normal notification replies retain existing behavior.
- Replies still work after a conversation is moved between mailboxes.
- Invalid notification hashes and non-notification Message-IDs are ignored.

```
OK (32 tests, 97 assertions)
```