### PR TITLE
Make Shebang in update.sh generic

### DIFF
--- a/tools/update.sh
+++ b/tools/update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # FreeScout upgrade script.
 # 


### PR DESCRIPTION
The more generic Shebang works also on e.g. FreeBSD, which has the Bash executable at `/usr/local/bin/bash`.