### PR TITLE
fix: compute Customer Waiting Since from thread history instead of last_reply_at

### DIFF
--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -1230,16 +1230,11 @@ class FetchEmails extends Command
         if ($conversation->status != Conversation::STATUS_ACTIVE && $conversation->status != Conversation::STATUS_SPAM) {
             $conversation->status = \Eventy::filter('conversation.status_changing', Conversation::STATUS_ACTIVE, $conversation);
         }
-        // This broke conversations order.
-        // https://github.com/freescout-help-desk/freescout/issues/5501#issuecomment-5084418616
-        //
-        // Only update last_reply_at if the customer was not already the last to reply.
-        // This preserves the original "waiting since" time when consecutive customer
-        // messages arrive without a staff reply in between.
-        // https://github.com/freescout-help-desk/freescout/issues/5225
-        /*if ($conversation->last_reply_from != Conversation::PERSON_CUSTOMER) {
-            $conversation->last_reply_at = $now;
-        }*/
+        // last_reply_at always reflects the true last activity time: it also drives
+        // folder list ordering (see Folder::getOrderByArray()), so it must advance on
+        // every incoming customer message, even consecutive ones without a staff reply
+        // in between (see #5501). The "waiting since" display is computed separately
+        // from thread history in Conversation::getCustomerWaitingSince() (see #5225).
         $conversation->last_reply_at = $now;
         $conversation->last_reply_from = Conversation::PERSON_CUSTOMER;
         // Reply from customer to deleted conversation should undelete it.

--- a/app/Conversation.php
+++ b/app/Conversation.php
@@ -1657,14 +1657,59 @@ class Conversation extends Model
         }
         $waiting_since_field = $folder->getWaitingSinceField();
         if ($waiting_since_field) {
-            // For phone conversations.
-            if (empty($this->$waiting_since_field)) {
-                $waiting_since_field = 'updated_at';
+            // last_reply_at reflects the time of the last activity of any kind (it also
+            // drives folder list ordering), not specifically how long the customer has
+            // been waiting for a reply. When the customer is the last person to have
+            // replied, compute the actual wait start from thread history instead so that
+            // consecutive customer messages don't keep resetting the displayed time
+            // (#5225), without touching last_reply_at itself (#5501).
+            if ($waiting_since_field == 'last_reply_at' && $this->last_reply_from == self::PERSON_CUSTOMER) {
+                $waiting_since_value = $this->getCustomerWaitingSince();
+            } else {
+                $waiting_since_value = $this->$waiting_since_field;
             }
-            return \App\User::dateDiffForHumans($this->$waiting_since_field);
+
+            // For phone conversations, and as a general fallback.
+            if (empty($waiting_since_value)) {
+                $waiting_since_value = $this->updated_at;
+            }
+            return \App\User::dateDiffForHumans($waiting_since_value);
         } else {
             return '';
         }
+    }
+
+    /**
+     * Get the timestamp from which the customer has been waiting for a reply,
+     * i.e. the creation time of the first thread in the current, unbroken run
+     * of customer messages. Unlike last_reply_at (which advances on every new
+     * thread so that folder lists keep sorting by true recency), this walks
+     * the conversation's threads backwards and stops as soon as it hits a
+     * reply that wasn't from the customer.
+     */
+    public function getCustomerWaitingSince()
+    {
+        $waiting_since = $this->last_reply_at;
+
+        $types = [Thread::TYPE_CUSTOMER, Thread::TYPE_MESSAGE];
+        if ($this->isPhone()) {
+            $types[] = Thread::TYPE_NOTE;
+        }
+
+        $threads = $this->threads()
+            ->whereIn('type', $types)
+            ->where('state', Thread::STATE_PUBLISHED)
+            ->orderBy('created_at', 'desc')
+            ->get(['source_via', 'created_at']);
+
+        foreach ($threads as $thread) {
+            if ($thread->source_via != self::PERSON_CUSTOMER) {
+                break;
+            }
+            $waiting_since = $thread->created_at;
+        }
+
+        return $waiting_since;
     }
 
     /**

--- a/app/Observers/ThreadObserver.php
+++ b/app/Observers/ThreadObserver.php
@@ -48,18 +48,11 @@ class ThreadObserver
             // $conversation->cc = $thread->cc;
             // $conversation->bcc = $thread->bcc;
 
-            // This broke conversations order.
-            // https://github.com/freescout-help-desk/freescout/issues/5501#issuecomment-5084418616
-            //
-            // Only update last_reply_at if the sender changed or it is not a consecutive
-            // customer message. This preserves the original "waiting since" time when
-            // multiple customer messages arrive without a staff reply.
-            // https://github.com/freescout-help-desk/freescout/issues/5225
-            /*if ($thread->source_via != Conversation::PERSON_CUSTOMER
-                || $conversation->last_reply_from != Conversation::PERSON_CUSTOMER
-            ) {
-                $conversation->last_reply_at = $now;
-            }*/
+            // last_reply_at always reflects the true last activity time: it also drives
+            // folder list ordering (see Folder::getOrderByArray()), so it must advance on
+            // every new thread, even consecutive customer messages without a staff reply
+            // in between (see #5501). The "waiting since" display is computed separately
+            // from thread history in Conversation::getCustomerWaitingSince() (see #5225).
             $conversation->last_reply_at = $now;
             $conversation->last_reply_from = $thread->source_via;
         }


### PR DESCRIPTION
## Problem

PR #5475 fixed #5225 (*Customer Waiting Since* jumping to the time of each new customer message instead of staying at the first unanswered one) by skipping the `last_reply_at` update whenever the customer was already the last to reply.

That broke conversation ordering (#5501): `last_reply_at` is also the field `Folder::getOrderByArray()` sorts folder lists by (`desc`), so freezing it on repeat customer messages stopped those conversations from bubbling to the top — a customer could send a 2nd or 3rd follow-up and the conversation would stay stuck in its old position, making it easy for agents to miss. The fix was reverted.

## Root cause

`last_reply_at` is overloaded with two incompatible responsibilities:
1. **Recency for folder ordering** — must advance on *every* new thread, customer or staff.
2. **Wait-start anchor for the "Waiting Since" metric** — must *not* advance on consecutive customer messages once the customer is already waiting.

PR #5475 fixed (2) by breaking (1), because both read/write the same column.

## Fix

- `FetchEmails.php` / `ThreadObserver.php`: revert to unconditionally updating `last_reply_at`/`last_reply_from` on every thread (restores pre-#5475 behavior, fixes #5501).
- `Conversation.php`: add `getCustomerWaitingSince()`, which — only when the customer is the current last replier — walks the conversation's threads backwards from most recent and stops at the first non-customer reply, returning the timestamp of the oldest thread in that unbroken run. `getWaitingSince()` uses this instead of the raw `last_reply_at` column when applicable. `Folder::getWaitingSince()` (which *picks* the featured conversation) is untouched — only the *displayed* value for that conversation changes.

This keeps the two concerns fully decoupled: no schema change, no change to which conversation sorts where — only the "waiting since" text shown for a conversation where the customer is the last replier.

## Tested scenarios (same table as #5475)

| Scenario | Expected `Waiting Since` | Result |
|---|---|---|
| Two consecutive customer messages | Time of first message | ✅ |
| Three consecutive customer messages | Time of first message | ✅ |
| Customer → staff → customer | Time of last customer message | ✅ |
| First message (new conversation) | Message time | ✅ |
| Two consecutive staff messages | Time of last staff message | ✅ |
| Two consecutive customer messages, no staff reply | Conversation still sorts by latest activity in folder lists (#5501 no longer regresses) | ✅ |

Closes #5225