### PR TITLE
Remove Outlook reply header from replies to email notifications - fixes #5545

### DIFF
--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -1633,6 +1633,14 @@ class FetchEmails extends Command
                     $parts = explode($reply_separator, $result);
                 }
                 if (count($parts) > 1) {
+                    // When replying to an email notification Outlook places its reply header
+                    // (<hr> + div#divRplyFwdMsg containing From/Sent/To/Subject) above the
+                    // quoted notification, i.e. above the separator, so it has to be removed
+                    // from the extracted reply separately.
+                    // https://github.com/freescout-help-desk/freescout/issues/5545
+                    if ($user_reply_to_notification) {
+                        $parts[0] = preg_replace('/<hr[^>]*>\s*<div[^>]+id="(?:x_)?divRplyFwdMsg".*$/is', '', $parts[0]) ?: $parts[0];
+                    }
                     // Check if part contains any real text.
                     $text = \Helper::htmlToText($parts[0]);
                     $text = trim($text);

--- a/tests/Unit/ReplySeparationTest.php
+++ b/tests/Unit/ReplySeparationTest.php
@@ -24,4 +24,31 @@ class ReplySeparationTest extends TestCase
             $this->assertEquals($body_separated, $separated_reply);
         }
     }
+
+    // Original body and body after separating the user's reply to the email notification.
+    // Outlook places its reply header (<hr> + div#divRplyFwdMsg) above the quoted
+    // notification, so it has to be removed from the extracted reply separately.
+    // https://github.com/freescout-help-desk/freescout/issues/5545
+    public $test_notification_bodies = [
+        // Outlook mobile / OWA / new Outlook rewrite id and class of the notification
+        // marker table to "x_fsNotifReplyAbove" but keep the data-fs attribute intact.
+        'Hi
+<hr style="display:inline-block;width:98%" tabindex="-1">
+<div id="divRplyFwdMsg" dir="ltr"><font face="Calibri, sans-serif" style="font-size:11pt" color="#000000"><b>Von:</b> ...<br>
+<b>Gesendet:</b> ...<br></font>
+<div>&nbsp;</div>
+</div>
+<table bgcolor="#f8f9f9" width="100%" id="x_fsNotifReplyAbove" class="x_fsNotifReplyAbove" data-fs="fsNotifReplyAbove"><tbody><tr><td>Quoted notification</td></tr></tbody></table>' => '<p>Hi
+</p>',
+    ];
+
+    public function testIncomingNotificationReplySeparation()
+    {
+        $fetch_emails = new \App\Console\Commands\FetchEmails();
+
+        foreach ($this->test_notification_bodies as $body_original => $body_separated) {
+            $separated_reply = $fetch_emails->separateReply($body_original, $is_html = true, $is_reply = true, $user_reply_to_notification = true);
+            $this->assertEquals($body_separated, $separated_reply);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #5545.

When an agent replies to a FreeScout notification email from Outlook (Outlook mobile / OWA / new Outlook), Outlook inserts its localized reply header (`<hr>` + `<div id="divRplyFwdMsg">` with From/Sent/To/Subject) *above* the quoted notification. Since `separateReply()` splits at the `fsNotifReplyAbove` marker (which survives as `data-fs` even though Outlook rewrites `id`/`class` to `x_fsNotifReplyAbove`), everything above the marker — including that header — ends up in the thread and is sent to the customer.

This change strips the trailing reply header from the extracted part when processing a user's reply to a notification. It only removes content between the agent's reply and the separator, so it cannot cut into the agent's own text, and the exclusive notification-separator behavior from #3580 is kept. The `(?:x_)?` prefix covers Outlook's id rewriting of quoted content.

Added a test case to `tests/Unit/ReplySeparationTest.php` following the existing pattern (fails without the fix, passes with it). Also verified against the original Outlook mobile (Exchange Online) email from which #5545 was reported: the extracted reply no longer contains the From/Sent/To/Subject block. `vendor/bin/phpunit tests/Unit` passes (26 tests, 101 assertions).
